### PR TITLE
Fix compilation issues with GCC 4.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,11 @@ Release/
 *.out
 *.app
 
+# Test outputs
+*.gcda
+*.gcno
+*.gcov
+
 # =========================
 # Operating System Files
 # =========================

--- a/src/csv_reader.cpp
+++ b/src/csv_reader.cpp
@@ -23,7 +23,7 @@ namespace csv {
     }
 
     void CSVGuesser::guess_delim() {
-        /** Guess the delimiter of a DSV by scanning the first 100 lines by
+        /** Guess the delimiter of a CSV by scanning the first 100 lines by
          *  First assuming that the header is on the first row
          *  If the first guess returns too few rows, then we move to the second
          *  guess method
@@ -44,7 +44,7 @@ namespace csv {
          */
 
         CSVFormat format = DEFAULT_CSV;
-        char current_delim;
+        char current_delim{','};
         int max_rows = 0;
         int temp_rows = 0;
         size_t max_cols = 0;
@@ -79,7 +79,6 @@ namespace csv {
          */
 
         CSVFormat format = DEFAULT_CSV;
-        char current_delim;
         size_t max_rlen = 0;
         size_t header = 0;
 
@@ -104,7 +103,6 @@ namespace csv {
             if (max->second > guess.records.size() &&
                (max->first > max_rlen)) {
                 max_rlen = max->first;
-                current_delim = guess.delimiter;
                 header = guess.row_when[max_rlen];
             }
         }

--- a/src/csv_writer.cpp
+++ b/src/csv_writer.cpp
@@ -43,7 +43,7 @@ namespace csv {
         /** Open a file for writing
          *  @param[out] outfile Path of the file to be written to
          */
-        this->outfile = std::ofstream(outfile, std::ios_base::binary);
+        this->outfile.open(outfile, std::ios_base::binary);
     }
 
     void CSVWriter::write_row(vector<string> record, bool quote_minimal) {


### PR DESCRIPTION
Before these changes, building on Ubuntu 14.04 with gcc 4.8 yielded:
```
$ make all
g++ -c -O3 -Wall -pthread -std=c++11 src/csv_reader.cpp src/csv_stat.cpp src/csv_writer.cpp src/data_type.cpp -Isrc/
src/csv_reader.cpp: In member function ‘void csv::CSVGuesser::second_guess()’:
src/csv_reader.cpp:82:14: warning: variable ‘current_delim’ set but not used [-Wunused-but-set-variable]
         char current_delim;
              ^
src/csv_reader.cpp: In member function ‘bool csv::CSVGuesser::first_guess()’:
src/csv_reader.cpp:68:36: warning: ‘current_delim’ may be used uninitialized in this function [-Wmaybe-uninitialized]
         this->delim = current_delim;
                                    ^
src/csv_writer.cpp: In constructor ‘csv::CSVWriter::CSVWriter(std::string)’:
src/csv_writer.cpp:46:23: error: use of deleted function ‘std::basic_ofstream<char>& std::basic_ofstream<char>::operator=(const std::basic_ofstream<char>&)’
         this->outfile = std::ofstream(outfile, std::ios_base::binary);
                       ^
In file included from src/csv_parser.h:6:0,
                 from src/csv_writer.cpp:1:
/usr/include/c++/4.8/fstream:599:11: note: ‘std::basic_ofstream<char>& std::basic_ofstream<char>::operator=(const std::basic_ofstream<char>&)’ is implicitly deleted because the default definition would be ill-formed:
     class basic_ofstream : public basic_ostream<_CharT,_Traits>
           ^
/usr/include/c++/4.8/fstream:599:11: error: use of deleted function ‘std::basic_ostream<char>& std::basic_ostream<char>::operator=(const std::basic_ostream<char>&)’
In file included from /usr/include/c++/4.8/iostream:39:0,
                 from src/csv_parser.h:5,
                 from src/csv_writer.cpp:1:
/usr/include/c++/4.8/ostream:58:11: note: ‘std::basic_ostream<char>& std::basic_ostream<char>::operator=(const std::basic_ostream<char>&)’ is implicitly deleted because the default definition would be ill-formed:
     class basic_ostream : virtual public basic_ios<_CharT, _Traits>
           ^
/usr/include/c++/4.8/ostream:58:11: error: use of deleted function ‘std::basic_ios<char>& std::basic_ios<char>::operator=(const std::basic_ios<char>&)’
In file included from /usr/include/c++/4.8/ios:44:0,
                 from /usr/include/c++/4.8/ostream:38,
                 from /usr/include/c++/4.8/iostream:39,
                 from src/csv_parser.h:5,
                 from src/csv_writer.cpp:1:
/usr/include/c++/4.8/bits/basic_ios.h:66:11: note: ‘std::basic_ios<char>& std::basic_ios<char>::operator=(const std::basic_ios<char>&)’ is implicitly deleted because the default definition would be ill-formed:
     class basic_ios : public ios_base
           ^
In file included from /usr/include/c++/4.8/ios:42:0,
                 from /usr/include/c++/4.8/ostream:38,
                 from /usr/include/c++/4.8/iostream:39,
                 from src/csv_parser.h:5,
                 from src/csv_writer.cpp:1:
/usr/include/c++/4.8/bits/ios_base.h:795:5: error: ‘std::ios_base& std::ios_base::operator=(const std::ios_base&)’ is private
     operator=(const ios_base&);
     ^
In file included from /usr/include/c++/4.8/ios:44:0,
                 from /usr/include/c++/4.8/ostream:38,
                 from /usr/include/c++/4.8/iostream:39,
                 from src/csv_parser.h:5,
                 from src/csv_writer.cpp:1:
/usr/include/c++/4.8/bits/basic_ios.h:66:11: error: within this context
     class basic_ios : public ios_base
           ^
In file included from src/csv_parser.h:6:0,
                 from src/csv_writer.cpp:1:
/usr/include/c++/4.8/fstream:599:11: error: use of deleted function ‘std::basic_filebuf<char>& std::basic_filebuf<char>::operator=(const std::basic_filebuf<char>&)’
     class basic_ofstream : public basic_ostream<_CharT,_Traits>
           ^
/usr/include/c++/4.8/fstream:72:11: note: ‘std::basic_filebuf<char>& std::basic_filebuf<char>::operator=(const std::basic_filebuf<char>&)’ is implicitly deleted because the default definition would be ill-formed:
     class basic_filebuf : public basic_streambuf<_CharT, _Traits>
           ^
In file included from /usr/include/c++/4.8/ios:43:0,
                 from /usr/include/c++/4.8/ostream:38,
                 from /usr/include/c++/4.8/iostream:39,
                 from src/csv_parser.h:5,
                 from src/csv_writer.cpp:1:
/usr/include/c++/4.8/streambuf:810:7: error: ‘std::basic_streambuf<_CharT, _Traits>& std::basic_streambuf<_CharT, _Traits>::operator=(const std::basic_streambuf<_CharT, _Traits>&) [with _CharT = char; _Traits = std::char_traits<char>]’ is private
       operator=(const basic_streambuf&) { return *this; };
       ^
In file included from src/csv_parser.h:6:0,
                 from src/csv_writer.cpp:1:
/usr/include/c++/4.8/fstream:72:11: error: within this context
     class basic_filebuf : public basic_streambuf<_CharT, _Traits>
           ^
make: *** [csv_parser] Error 1
```

After these changes, I have no warnings or errors, and all tests passed:
```
$ make all
g++ -c -O3 -Wall -pthread -std=c++11 src/csv_reader.cpp src/csv_stat.cpp src/csv_writer.cpp src/data_type.cpp -Isrc/
mkdir -p build
mv *.o build
make run_test_csv_parser
make[1]: Entering directory `/home/bschober/git/dynon-csv-parser'
g++ -o test_csv_parser src/csv_reader.cpp src/csv_stat.cpp src/csv_writer.cpp src/data_type.cpp tests/main.cpp tests/test_csv_stat.cpp tests/test_data_type.cpp tests/test_read_csv.cpp tests/test_write_csv.cpp -Isrc/ -Itests/ -pthread -std=c++11 -Og -g --coverage
mkdir -p tests/temp
./test_csv_parser
===============================================================================
All tests passed (116078 assertions in 34 test cases)

# Test Clean-Up
rm -rf tests/temp
make[1]: Leaving directory `/home/bschober/git/dynon-csv-parser'
make code_cov
make[1]: Entering directory `/home/bschober/git/dynon-csv-parser'
mkdir -p test_results
mv *.gcno *.gcda /home/bschober/git/dynon-csv-parser/test_results
gcov src/csv_reader.cpp src/csv_stat.cpp src/csv_writer.cpp src/data_type.cpp -o test_results --relative-only
File 'src/csv_reader.cpp'
Lines executed:95.61% of 296
Creating 'csv_reader.cpp.gcov'

File 'src/csv_parser.h'
Lines executed:95.24% of 21
Creating 'csv_parser.h.gcov'

File 'src/csv_stat.cpp'
Lines executed:97.96% of 98
Creating 'csv_stat.cpp.gcov'

File 'src/csv_writer.cpp'
Lines executed:98.15% of 54
Creating 'csv_writer.cpp.gcov'

File 'src/data_type.cpp'
Lines executed:100.00% of 16
Creating 'data_type.cpp.gcov'

Lines executed:96.49% of 485
mv *.gcov test_results
make[1]: Leaving directory `/home/bschober/git/dynon-csv-parser'
rm -rf test_csv_parser
```