### PR TITLE
Don't include inside namespaces

### DIFF
--- a/include/internal/constants.hpp
+++ b/include/internal/constants.hpp
@@ -7,14 +7,18 @@
 
 #include "csv_format.hpp"
 
+#if defined(_WIN32)
+#include <Windows.h>
+#undef max
+#undef min
+#elif defined(__linux__)
+#include <unistd.h>
+#endif
+
 namespace csv {
     namespace internals {
         // Get operating system specific details
         #if defined(_WIN32)
-            #include <Windows.h>
-            #undef max
-            #undef min
-
             inline int getpagesize() {
                 _SYSTEM_INFO sys_info = {};
                 GetSystemInfo(&sys_info);
@@ -24,7 +28,6 @@ namespace csv {
             /** Size of a memory page in bytes */
             const int PAGE_SIZE = getpagesize();
         #elif defined(__linux__) 
-            #include <unistd.h>
             const int PAGE_SIZE = getpagesize();
         #else
             const int PAGE_SIZE = 4096;


### PR DESCRIPTION
Removing includes inside the `csv::internals` namespace, because it makes symbols defined inside `unistd.h` to be found by the compiler only inside that namespace.

This means that if I have other dependency that uses `unistd.h` header file, it won't compile because it won't be able to find things defined as `extern`, such as (for example) `extern long int syscall (long int __sysno, ...) __THROW;`