### PR TITLE
Fix various minor issues with clang:

### DIFF
--- a/include/internal/compatibility.hpp
+++ b/include/internal/compatibility.hpp
@@ -53,7 +53,7 @@ namespace csv {
     #endif
 
     // Resolves g++ bug with regard to constexpr methods
-    #ifdef __GNUC__
+    #if defined __GNUC__ && !defined __clang__
         #if __GNUC__ >= 7
             #if defined(CSV_HAS_CXX17) && (__GNUC_MINOR__ >= 2 || __GNUC__ >= 8)
                 #define CONSTEXPR constexpr

--- a/include/internal/csv_reader.cpp
+++ b/include/internal/csv_reader.cpp
@@ -427,7 +427,7 @@ namespace csv {
 
     CONSTEXPR void CSVReader::handle_unicode_bom(csv::string_view& in) {
         if (!this->unicode_bom_scan) {
-            if (in[0] == 0xEF && in[1] == 0xBB && in[2] == 0xEF) {
+            if (in[0] == (char)0xEF && in[1] == (char)0xBB && in[2] == (char)0xEF) {
                 in.remove_prefix(3); // Remove BOM from input string
                 this->utf8_bom = true;
             }

--- a/include/internal/csv_reader.cpp
+++ b/include/internal/csv_reader.cpp
@@ -427,7 +427,7 @@ namespace csv {
 
     CONSTEXPR void CSVReader::handle_unicode_bom(csv::string_view& in) {
         if (!this->unicode_bom_scan) {
-            if (in[0] == (char)0xEF && in[1] == (char)0xBB && in[2] == (char)0xEF) {
+            if (in[0] == '\xEF' && in[1] == '\xBB' && in[2] == '\xBF') {            
                 in.remove_prefix(3); // Remove BOM from input string
                 this->utf8_bom = true;
             }

--- a/include/internal/csv_row.cpp
+++ b/include/internal/csv_row.cpp
@@ -116,7 +116,7 @@ namespace csv {
         return this->buffer->split_buffer[this->start + n];
     }
 
-    HEDLEY_NON_NULL(1)
+    HEDLEY_NON_NULL(2)
     CSVRow::iterator::iterator(const CSVRow* _reader, int _i)
         : daddy(_reader), i(_i) {
         if (_i < (int)this->daddy->size())

--- a/include/internal/row_buffer.hpp
+++ b/include/internal/row_buffer.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <vector>
 #include <unordered_map>
+#include <string>
 
 #include "compatibility.hpp" // For string view
 


### PR DESCRIPTION
- clang detected as gnuc 4.2
- (signed) char comparison with integer >= 128 always false
- nonnull attribute referring to 1 is the implicit 'this' pointer
- missing #include <string>