### PR TITLE
Single include test must link threads.

### DIFF
--- a/single_include_test/CMakeLists.txt
+++ b/single_include_test/CMakeLists.txt
@@ -5,3 +5,4 @@ target_sources(single_include_test
         file1.cpp
         file2.cpp
 )
+target_link_libraries(single_include_test PRIVATE Threads::Threads)


### PR DESCRIPTION
This fixes the failure of the build on Linux for me. (Note that I still get warnings - #78 fixes those.)