### PR TITLE
Refactored CSVReader/first-class support for handling variable column rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,20 @@ This CSV parser uses multiple threads to simulatenously pull data from disk and 
 
 On my computer (Intel Core i7-8550U @ 1.80GHz/Toshiba XG5 SSD), it is capable of parsing the [69.9 MB 2015_StateDepartment.csv](https://github.com/vincentlaucsb/csv-data/tree/master/real_data) in 0.33 seconds.
 
-### Robust
-#### RFC 4180 Compliance
-This CSV parser is much more than a fancy string splitter, and follows every guideline from [RFC 4180](https://www.rfc-editor.org/rfc/rfc4180.txt). An optional strict parsing mode can be enabled to sniff out errors in files.
+### Robust Yet Flexible
+#### RFC 4180 and Beyond
+This CSV parser is much more than a fancy string splitter, and parses all files following [RFC 4180](https://www.rfc-editor.org/rfc/rfc4180.txt).
 
-#### Non-RFC 4180 Deviations
-We know that actual CSV files come with many different quirks. In addition, there are many CSV-inspired formats like tab-separated values. Thus, this CSV library has many features for dealing with this reality:
+However, in reality we know that RFC 4180 is just a suggestion, and there's many "flavors" of CSV such as tab-delimited files. Thus, this library has:
  * Automatic delimiter guessing
  * Ability to ignore comments in leading rows and elsewhere
  * Ability to handle rows of different lengths
 
+By default, rows of variable length are silently ignored, although you may elect to keep them or throw an error.
+
 #### Encoding
-This CSV parser will handle ANSI and UTF-8 encoded files. It does not try to decode UTF-8, except for detecting and stripping byte order marks.
+This CSV parser is encoding-agnostic and will handle ANSI and UTF-8 encoded files.
+It does not try to decode UTF-8, except for detecting and stripping UTF-8 byte order marks.
 
 ### Well Tested
 This CSV parser has an extensive test suite and is checked for memory safety with Valgrind. If you still manage to find a bug,
@@ -233,6 +235,25 @@ to trim.
 ```cpp
 CSVFormat format;
 format.trim({ ' ', '\t'  });
+```
+
+#### Handling Variable Numbers of Columns
+Sometimes, the rows in a CSV are not all of the same length. Whether this was intentional or not,
+this library is built to handle all use cases.
+
+```cpp
+CSVFormat format;
+
+// Default: Silently ignoring rows with missing or extraneous columns
+format.variable_columns(false); // Short-hand
+format.variable_columns(VariableColumnPolicy::IGNORE);
+
+// Case 2: Keeping variable-length rows
+format.variable_columns(true); // Short-hand
+format.variable_columns(VariableColumnPolicy::KEEP);
+
+// Case 3: Throwing an error if variable-length rows are encountered
+format.variable_columns(VariableColumnPolicy::THROW);
 ```
 
 #### Setting Column Names

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
    * [Numeric Conversions](#numeric-conversions)
    * [Specifying the CSV Format](#specifying-the-csv-format)
       * [Trimming Whitespace](#trimming-whitespace)
+      * [Handling Variable Numbers of Columns](#handling-variable-numbers-of-columns)
       * [Setting Column Names](#setting-column-names)
    * [Converting to JSON](#converting-to-json)
    * [Parsing an In-Memory String](#parsing-an-in-memory-string)

--- a/include/csv.hpp
+++ b/include/csv.hpp
@@ -1,5 +1,5 @@
 /*
-CSV for C++, version 2.0.0
+CSV for C++, version 1.6.0
 https://github.com/vincentlaucsb/csv-parser
 
 MIT License

--- a/include/csv.hpp
+++ b/include/csv.hpp
@@ -1,5 +1,5 @@
 /*
-CSV for C++, version 1.2.5.1
+CSV for C++, version 2.0.0
 https://github.com/vincentlaucsb/csv-parser
 
 MIT License

--- a/include/internal/CMakeLists.txt
+++ b/include/internal/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(csv
 		csv_format.cpp
 		csv_reader.hpp
 		csv_reader.cpp
+		csv_reader_internals.hpp
 		csv_reader_iterator.cpp
 		csv_row.hpp
 		csv_row.cpp

--- a/include/internal/CMakeLists.txt
+++ b/include/internal/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(csv
 		csv_reader.hpp
 		csv_reader.cpp
 		csv_reader_internals.hpp
+        csv_reader_internals.cpp
 		csv_reader_iterator.cpp
 		csv_row.hpp
 		csv_row.cpp

--- a/include/internal/compatibility.hpp
+++ b/include/internal/compatibility.hpp
@@ -15,9 +15,6 @@
 // See: https://github.com/nemequ/hedley
 #include "../external/hedley.h"
 
-/** Used to supress unused variable warning in g++ */
-#define SUPPRESS_UNUSED_WARNING(x) (void)x
-
 namespace csv {
     /**
      *  @def IF_CONSTEXPR

--- a/include/internal/constants.hpp
+++ b/include/internal/constants.hpp
@@ -41,7 +41,4 @@ namespace csv {
 
     /** Used for counting number of rows */
     using RowCount = long long int;
-
-    class CSVRow;
-    using CSVCollection = std::deque<CSVRow>;
 }

--- a/include/internal/constants.hpp
+++ b/include/internal/constants.hpp
@@ -36,8 +36,11 @@ namespace csv {
         /** For functions that lazy load a large CSV, this determines how
          *  many bytes are read at a time
          */
-        const size_t ITERATION_CHUNK_SIZE = 50000000; // 50MB
+        constexpr size_t ITERATION_CHUNK_SIZE = 50000000; // 50MB
     }
+
+    /** Integer indicating a requested column wasn't found. */
+    constexpr int CSV_NOT_FOUND = -1;
 
     /** Used for counting number of rows */
     using RowCount = long long int;

--- a/include/internal/csv_format.hpp
+++ b/include/internal/csv_format.hpp
@@ -79,7 +79,7 @@ namespace csv {
         }
 
         #ifndef DOXYGEN_SHOULD_SKIP_THIS
-        char get_delim() {
+        char get_delim() const {
             // This error should never be received by end users.
             if (this->possible_delimiters.size() > 1) {
                 throw std::runtime_error("There is more than one possible delimiter.");

--- a/include/internal/csv_format.hpp
+++ b/include/internal/csv_format.hpp
@@ -10,6 +10,10 @@
 #include "compatibility.hpp"
 
 namespace csv {
+    namespace internals {
+
+    }
+
     class CSVReader;
 
     /** Stores the inferred format of a CSV file. */
@@ -126,6 +130,15 @@ namespace csv {
 
         friend CSVReader;
         friend std::vector<std::string> get_col_names(csv::string_view, CSVFormat);
+        // friend std::vector<std::string> internals::_get_col_names(csv::string_view, CSVFormat);
+
+
+        /**< Set of whitespace characters to trim */
+        std::vector<char> trim_chars = {};
+
+        /**< Row number with columns (ignored if col_names is non-empty) */
+        int header = 0;
+
     private:
         /**< Throws an error if delimiters and trim characters overlap */
         void assert_no_char_overlap();
@@ -133,14 +146,10 @@ namespace csv {
         /**< Set of possible delimiters */
         std::vector<char> possible_delimiters = { ',' };
 
-        /**< Set of whitespace characters to trim */
-        std::vector<char> trim_chars = {};
 
         /**< Quote character */
         char quote_char = '"';
 
-        /**< Row number with columns (ignored if col_names is non-empty) */
-        int header = 0;
 
         /**< Should be left empty unless file doesn't include header */
         std::vector<std::string> col_names = {};

--- a/include/internal/csv_format.hpp
+++ b/include/internal/csv_format.hpp
@@ -125,7 +125,7 @@ namespace csv {
         }
 
         friend CSVReader;
-        friend std::vector<std::string> get_col_names(const std::string&, CSVFormat);
+        friend std::vector<std::string> get_col_names(csv::string_view, CSVFormat);
     private:
         /**< Throws an error if delimiters and trim characters overlap */
         void assert_no_char_overlap();

--- a/include/internal/csv_format.hpp
+++ b/include/internal/csv_format.hpp
@@ -88,6 +88,10 @@ namespace csv {
             return this->possible_delimiters.at(0);
         }
 
+        std::vector<char> get_possible_delims() {
+            return this->possible_delimiters;
+        }
+
         CONSTEXPR int get_header() {
             return this->header;
         }
@@ -116,12 +120,13 @@ namespace csv {
             return format;
         }
 
-        friend CSVReader;
-    private:
         bool guess_delim() {
             return this->possible_delimiters.size() > 1;
         }
 
+        friend CSVReader;
+        friend std::vector<std::string> get_col_names(const std::string&, CSVFormat);
+    private:
         /**< Throws an error if delimiters and trim characters overlap */
         void assert_no_char_overlap();
 

--- a/include/internal/csv_format.hpp
+++ b/include/internal/csv_format.hpp
@@ -12,6 +12,7 @@
 namespace csv {
     class CSVReader;
 
+    /** Determines how to handle rows that are shorter or longer than the majority */
     enum class VariableColumnPolicy {
         THROW = -1,
         IGNORE = 0,
@@ -98,12 +99,10 @@ namespace csv {
             return this->possible_delimiters.at(0);
         }
 
-        std::vector<char> get_possible_delims() {
-            return this->possible_delimiters;
-        }
-
         CONSTEXPR int get_header() const { return this->header; }
-        CONSTEXPR VariableColumnPolicy get_variable_column_policy() const { return this->get_variable_column_policy(); }
+        std::vector<char> get_possible_delims() const { return this->possible_delimiters; }
+        std::vector<char> get_trim_chars() const { return this->trim_chars; }
+        CONSTEXPR VariableColumnPolicy get_variable_column_policy() const { return this->variable_column_policy; }
         #endif
         
         /** CSVFormat for guessing the delimiter */
@@ -122,15 +121,6 @@ namespace csv {
         }
 
         friend CSVReader;
-        friend std::vector<std::string> get_col_names(csv::string_view, CSVFormat);
-        // friend std::vector<std::string> internals::_get_col_names(csv::string_view, CSVFormat);
-
-
-        /**< Set of whitespace characters to trim */
-        std::vector<char> trim_chars = {};
-
-        /**< Row number with columns (ignored if col_names is non-empty) */
-        int header = 0;
 
     private:
         /**< Throws an error if delimiters and trim characters overlap */
@@ -138,6 +128,12 @@ namespace csv {
 
         /**< Set of possible delimiters */
         std::vector<char> possible_delimiters = { ',' };
+
+        /**< Set of whitespace characters to trim */
+        std::vector<char> trim_chars = {};
+
+        /**< Row number with columns (ignored if col_names is non-empty) */
+        int header = 0;
 
         /**< Quote character */
         char quote_char = '"';

--- a/include/internal/csv_reader.cpp
+++ b/include/internal/csv_reader.cpp
@@ -41,9 +41,8 @@ namespace csv {
                 internals::make_parse_flags(format.get_delim(), '"'),
                 internals::make_ws_flags(format.trim_chars.data(), format.trim_chars.size()),
                 buffer_ptr,
-                false,
                 rows
-                });
+            });
 
             return rows[format.header];
         }
@@ -79,9 +78,8 @@ namespace csv {
                     internals::make_parse_flags(cand_delim, '"'),
                     internals::make_ws_flags({}, 0),
                     buffer_ptr,
-                    false,
                     rows
-                    });
+                });
 
                 for (size_t i = 0; i < rows.size(); i++) {
                     auto& row = rows[i];
@@ -243,7 +241,6 @@ namespace csv {
             this->parse_flags,
             this->ws_flags,
             this->record_buffer,
-            this->format.strict,
             this->records
         });
 
@@ -411,11 +408,13 @@ namespace csv {
         }
 
         while (!this->records.empty()) {
-            if (this->records.front().size() != this->n_cols) {
-                if (this->format.strict) {
-                    throw std::runtime_error("Line too short");
+            if (this->records.front().size() != this->n_cols &&
+                this->format.variable_column_policy != VariableColumnPolicy::KEEP) {
+                if (this->format.variable_column_policy == VariableColumnPolicy::THROW) {
+                    throw std::runtime_error("Line too short " + internals::format_row(this->records.front()));
                 }
 
+                // Silently drop row (default)
                 this->records.pop_front();
             }
             else {

--- a/include/internal/csv_reader.cpp
+++ b/include/internal/csv_reader.cpp
@@ -273,8 +273,8 @@ namespace csv {
         }
 
         if (!this->pre_header_trimmed) {
-            for (size_t i = 0; i <= this->header_row && !this->records.empty(); i++) {
-                if (i == this->header_row && !this->col_names) {
+            for (int i = 0; i <= this->header_row && !this->records.empty(); i++) {
+                if (i == this->header_row && this->col_names->get_col_names().empty()) {
                     this->set_col_names(this->records.front());
                 }
 

--- a/include/internal/csv_reader.cpp
+++ b/include/internal/csv_reader.cpp
@@ -275,6 +275,15 @@ namespace csv {
                 std::string(in.substr(i, 100)));
                 */
         }
+
+        if (!this->pre_header_trimmed) {
+            for (size_t i = 0; i <= this->header_row && !this->records.empty(); i++) {
+                this->records.pop_front();
+                this->correct_rows--;
+            }
+
+            this->pre_header_trimmed = true;
+        }
     }
 
     CSV_INLINE void CSVReader::end_feed() {
@@ -300,21 +309,14 @@ namespace csv {
          *  Drop it otherwise.
          */
 
-        if (this->row_num > this->header_row) {
-            // Make sure record is of the right length
-            const size_t row_size = this->record_buffer->splits_size();
-            if (row_size + 1 == this->n_cols) {
-                this->correct_rows++;
-                this->records.push_back(CSVRow(this->record_buffer));
-            }
-            else {
-                this->row_num--;
-                this->record_buffer->get_row();
-                this->record_buffer->get_splits();
-            }
+        // Make sure record is of the right length
+        const size_t row_size = this->record_buffer->splits_size();
+        if (row_size + 1 == this->n_cols) {
+            this->correct_rows++;
+            this->records.push_back(CSVRow(this->record_buffer));
         }
         else {
-            // Ignore rows before header row
+            this->row_num--;
             this->record_buffer->get_row();
             this->record_buffer->get_splits();
         }

--- a/include/internal/csv_reader.cpp
+++ b/include/internal/csv_reader.cpp
@@ -415,7 +415,11 @@ namespace csv {
             if (this->records.front().size() != this->n_cols &&
                 this->format.variable_column_policy != VariableColumnPolicy::KEEP) {
                 if (this->format.variable_column_policy == VariableColumnPolicy::THROW) {
-                    throw std::runtime_error("Line too short " + internals::format_row(this->records.front()));
+                    if (this->records.front().size() < this->n_cols) {
+                        throw std::runtime_error("Line too short " + internals::format_row(this->records.front()));
+                    }
+
+                    throw std::runtime_error("Line too long " + internals::format_row(this->records.front()));
                 }
 
                 // Silently drop row (default)

--- a/include/internal/csv_reader.cpp
+++ b/include/internal/csv_reader.cpp
@@ -249,7 +249,9 @@ namespace csv {
         /** Indicate that there is no more data to receive,
          *  and handle the last row
          */
-        this->records.push_back(CSVRow(this->record_buffer));
+        if (this->record_buffer->size() > 0) {
+            this->records.push_back(CSVRow(this->record_buffer));
+        }
     }
 
     CONSTEXPR void CSVReader::handle_unicode_bom(csv::string_view& in) {

--- a/include/internal/csv_reader.cpp
+++ b/include/internal/csv_reader.cpp
@@ -131,8 +131,6 @@ namespace csv {
     /** Allows parsing in-memory sources (by calling feed() and end_feed()). */
     CSV_INLINE CSVReader::CSVReader(CSVFormat format) : 
         unicode_bom_scan(!format.unicode_detect), feed_state(new ThreadedReadingState)  {
-        this->record_buffer->col_names = this->col_names;
-
         if (!format.col_names.empty()) {
             this->set_col_names(format.col_names);
         }
@@ -157,8 +155,6 @@ namespace csv {
      *
      */
     CSV_INLINE CSVReader::CSVReader(csv::string_view filename, CSVFormat format) : feed_state(new ThreadedReadingState) {
-        this->record_buffer->col_names = this->col_names;
-
         /** Guess delimiter and header row */
         if (format.guess_delim()) {
             auto guess_result = guess_format(filename, format.possible_delimiters);
@@ -242,7 +238,7 @@ namespace csv {
             throw std::runtime_error("Unescaped single quote around line ");
             
             /** TODO: Add this back in+
-                std::to_string(this->correct_rows) + " near:\n" +
+                std::to_string(this->num_rows) + " near:\n" +
                 std::string(in.substr(i, 100)));
                 */
         }
@@ -419,7 +415,7 @@ namespace csv {
 
         if (!this->records.empty()) {
             row = std::move(this->records.front());
-            this->correct_rows++;
+            this->num_rows++;
             this->records.pop_front();
             return true;
         }

--- a/include/internal/csv_reader.cpp
+++ b/include/internal/csv_reader.cpp
@@ -2,9 +2,6 @@
  *  @brief Defines functionality needed for basic CSV parsing
  */
 
-#include "csv_reader.hpp"
-#include "csv_reader.hpp"
-#include "csv_reader.hpp"
 #include <algorithm>
 #include <cstdio>   // For read_csv()
 #include <cstring>  // For read_csv()
@@ -163,44 +160,6 @@ namespace csv {
         return guesser.guess_delim();
     }
 
-    HEDLEY_CONST CONSTEXPR
-    std::array<CSVReader::ParseFlags, 256> CSVReader::make_parse_flags() const {
-        std::array<ParseFlags, 256> ret = {};
-        for (int i = -128; i < 128; i++) {
-            const int arr_idx = i + 128;
-            char ch = char(i);
-
-            if (ch == this->delimiter)
-                ret[arr_idx] = DELIMITER;
-            else if (ch == this->quote_char)
-                ret[arr_idx] = QUOTE;
-            else if (ch == '\r' || ch == '\n')
-                ret[arr_idx] = NEWLINE;
-            else
-                ret[arr_idx] = NOT_SPECIAL;
-        }
-
-        return ret;
-    }
-
-    HEDLEY_CONST CONSTEXPR
-    std::array<bool, 256> CSVReader::make_ws_flags(const char * delims, size_t n_chars) const {
-        std::array<bool, 256> ret = {};
-        for (int i = -128; i < 128; i++) {
-            const int arr_idx = i + 128;
-            char ch = char(i);
-            ret[arr_idx] = false;
-
-            for (size_t j = 0; j < n_chars; j++) {
-                if (delims[j] == ch) {
-                    ret[arr_idx] = true;
-                }
-            }
-        }
-
-        return ret;
-    }
-
     CSV_INLINE void CSVReader::bad_row_handler(std::vector<std::string> record) {
         /** Handler for rejected rows (too short or too long). This does nothing
          *  unless strict parsing was set, in which case it throws an eror.
@@ -228,8 +187,8 @@ namespace csv {
             this->set_col_names(format.col_names);
         }
         
-        parse_flags = this->make_parse_flags();
-        ws_flags = this->make_ws_flags(format.trim_chars.data(), format.trim_chars.size());
+        parse_flags = internals::make_parse_flags(this->delimiter, this->quote_char);
+        ws_flags = internals::make_ws_flags(format.trim_chars.data(), format.trim_chars.size());
     };
 
     /** Allows reading a CSV file in chunks, using overlapped
@@ -262,8 +221,8 @@ namespace csv {
         delimiter = format.get_delim();
         quote_char = format.quote_char;
         strict = format.strict;
-        parse_flags = this->make_parse_flags();
-        ws_flags = this->make_ws_flags(format.trim_chars.data(), format.trim_chars.size());
+        parse_flags = internals::make_parse_flags(delimiter, quote_char);
+        ws_flags = internals::make_ws_flags(format.trim_chars.data(), format.trim_chars.size());
 
         // Read first 500KB of CSV
         this->fopen(filename);
@@ -318,6 +277,7 @@ namespace csv {
          *  @note
          *  `end_feed()` should be called after the last string.
          */
+        using internals::ParseFlags;
 
         this->handle_unicode_bom(in);
         bool quote_escape = false;  // Are we currently in a quote escaped field?
@@ -334,88 +294,89 @@ namespace csv {
         const size_t in_size = in.size();
         for (size_t i = 0; i < in_size; i++) {
             switch (_parse_flags[in[i] + 128]) {
-                case DELIMITER:
-                    if (!quote_escape) {
-                        split_buffer.push_back((unsigned short)row_buffer.size());
-                        break;
-                    }
-
-                    HEDLEY_FALL_THROUGH;
-                case NEWLINE:
-                    if (!quote_escape) {
-                        // End of record -> Write record
-                        if (i + 1 < in_size && in[i + 1] == '\n') // Catches CRLF (or LFLF)
-                            ++i;
-                        this->write_record();
-                        break;
-                    }
-
-                    // Treat as regular character
-                    text_buffer += in[i];
+            case ParseFlags::DELIMITER:
+                if (!quote_escape) {
+                    split_buffer.push_back((unsigned short)row_buffer.size());
                     break;
-                case NOT_SPECIAL: {
-                    size_t start, end;
+                }
 
-                    // Trim off leading whitespace
-                    while (i < in_size && _ws_flags[in[i] + 128]) {
-                        i++;
-                    }
+                HEDLEY_FALL_THROUGH;
+            case ParseFlags::NEWLINE:
+                if (!quote_escape) {
+                    // End of record -> Write record
+                    if (i + 1 < in_size && in[i + 1] == '\n') // Catches CRLF (or LFLF)
+                        ++i;
+                    this->write_record();
+                    break;
+                }
 
-                    start = i;
+                // Treat as regular character
+                text_buffer += in[i];
+                break;
+            case ParseFlags::NOT_SPECIAL: {
+                size_t start, end;
 
-                    // Optimization: Since NOT_SPECIAL characters tend to occur in contiguous
-                    // sequences, use the loop below to avoid having to go through the outer
-                    // switch statement as much as possible
-                    while (i + 1 < in_size && _parse_flags[in[i + 1] + 128] == NOT_SPECIAL) {
-                        i++;
-                    }
+                // Trim off leading whitespace
+                while (i < in_size && _ws_flags[in[i] + 128]) {
+                    i++;
+                }
 
-                    // Trim off trailing whitespace
-                    end = i;
-                    while (_ws_flags[in[end] + 128]) {
-                        end--;
-                    }
+                start = i;
 
-                    // Finally append text
+                // Optimization: Since NOT_SPECIAL characters tend to occur in contiguous
+                // sequences, use the loop below to avoid having to go through the outer
+                // switch statement as much as possible
+                while (i + 1 < in_size
+                    && _parse_flags[in[i + 1] + 128] == ParseFlags::NOT_SPECIAL) {
+                    i++;
+                }
+
+                // Trim off trailing whitespace
+                end = i;
+                while (_ws_flags[in[end] + 128]) {
+                    end--;
+                }
+
+                // Finally append text
 #ifdef CSV_HAS_CXX17
-                    text_buffer += in.substr(start, end - start + 1);
+                text_buffer += in.substr(start, end - start + 1);
 #else
-                    for (; start < end + 1; start++) {
-                        text_buffer += in[start];
-                    }
+                for (; start < end + 1; start++) {
+                    text_buffer += in[start];
+                }
 #endif
+
+                break;
+            }
+            default: // Quote
+                if (!quote_escape) {
+                    // Don't deref past beginning
+                    if (i && _parse_flags[in[i - 1] + 128] >= ParseFlags::DELIMITER) {
+                        // Case: Previous character was delimiter or newline
+                        quote_escape = true;
+                    }
 
                     break;
                 }
-                default: // Quote
-                    if (!quote_escape) {
-                        // Don't deref past beginning
-                        if (i && _parse_flags[in[i - 1] + 128] >= DELIMITER) {
-                            // Case: Previous character was delimiter or newline
-                            quote_escape = true;
-                        }
 
-                        break;
-                    }
-
-                    auto next_ch = _parse_flags[in[i + 1] + 128];
-                    if (next_ch >= DELIMITER) {
-                        // Case: Delim or newline => end of field
-                        quote_escape = false;
-                        break;
-                    }
-                        
-                    // Case: Escaped quote
-                    text_buffer += in[i];
-
-                    if (next_ch == QUOTE)
-                        ++i;  // Case: Two consecutive quotes
-                    else if (this->strict)
-                        throw std::runtime_error("Unescaped single quote around line " +
-                            std::to_string(this->correct_rows) + " near:\n" +
-                            std::string(in.substr(i, 100)));
-                        
+                auto next_ch = _parse_flags[in[i + 1] + 128];
+                if (next_ch >= ParseFlags::DELIMITER) {
+                    // Case: Delim or newline => end of field
+                    quote_escape = false;
                     break;
+                }
+                        
+                // Case: Escaped quote
+                text_buffer += in[i];
+
+                if (next_ch == ParseFlags::QUOTE)
+                    ++i;  // Case: Two consecutive quotes
+                else if (this->strict)
+                    throw std::runtime_error("Unescaped single quote around line " +
+                        std::to_string(this->correct_rows) + " near:\n" +
+                        std::string(in.substr(i, 100)));
+                        
+                break;
             }
         }
         

--- a/include/internal/csv_reader.cpp
+++ b/include/internal/csv_reader.cpp
@@ -182,9 +182,7 @@ namespace csv {
 
     /** Return the format of the original raw CSV */
     CSV_INLINE CSVFormat CSVReader::get_format() const {
-        CSVFormat new_format;
-        new_format.delimiter(this->format.get_delim())
-            .quote(this->format.quote_char);
+        CSVFormat new_format = this->format;
 
         // Since users are normally not allowed to set 
         // column names and header row simulatenously,

--- a/include/internal/csv_reader.cpp
+++ b/include/internal/csv_reader.cpp
@@ -410,22 +410,22 @@ namespace csv {
             else return false; // Stop reading
         }
 
-        while (!this->records.empty() && 
-            this->records.front().size() != this->n_cols) {
-            if (this->format.strict) {
-                throw std::runtime_error("Line too short");
+        while (!this->records.empty()) {
+            if (this->records.front().size() != this->n_cols) {
+                if (this->format.strict) {
+                    throw std::runtime_error("Line too short");
+                }
+
+                this->records.pop_front();
             }
-
-            this->records.pop_front();
+            else {
+                row = std::move(this->records.front());
+                this->num_rows++;
+                this->records.pop_front();
+                return true;
+            }
         }
-
-        if (!this->records.empty()) {
-            row = std::move(this->records.front());
-            this->num_rows++;
-            this->records.pop_front();
-            return true;
-        }
-
+    
         return false;
     }
 }

--- a/include/internal/csv_reader.cpp
+++ b/include/internal/csv_reader.cpp
@@ -128,24 +128,6 @@ namespace csv {
         return { current_delim, (int)header };
     }
 
-    CSV_INLINE void CSVReader::bad_row_handler(std::vector<std::string> record) {
-        /** Handler for rejected rows (too short or too long). This does nothing
-         *  unless strict parsing was set, in which case it throws an eror.
-         *  Subclasses of CSVReader may easily override this to provide
-         *  custom behavior.
-         */
-        if (this->strict) {
-            std::string problem;
-            if (record.size() > this->col_names->size()) problem = "too long";
-            else problem = "too short";
-
-            throw std::runtime_error("Line " + problem + " around line " +
-                std::to_string(correct_rows) + " near\n" +
-                internals::format_row(record)
-            );
-        }
-    };
-
     /** Allows parsing in-memory sources (by calling feed() and end_feed()). */
     CSV_INLINE CSVReader::CSVReader(CSVFormat format) :
         delimiter(format.get_delim()), quote_char(format.quote_char),
@@ -435,12 +417,11 @@ namespace csv {
 
         while (!this->records.empty() && 
             this->records.front().size() != this->n_cols) {
-            if (!this->strict) {
-                this->records.pop_front();
-            }
-            else {
+            if (this->strict) {
                 throw std::runtime_error("Line too short");
             }
+
+            this->records.pop_front();
         }
 
         if (!this->records.empty()) {

--- a/include/internal/csv_reader.cpp
+++ b/include/internal/csv_reader.cpp
@@ -69,12 +69,16 @@ namespace csv {
 
             for (size_t i = 0; i < rows.size(); i++) {
                 auto& row = rows[i];
-                if (row_tally.find(row.size()) != row_tally.end()) {
-                    row_tally[row.size()]++;
-                }
-                else {
-                    row_tally[row.size()] = 1;
-                    row_when[row.size()] = i;
+
+                // Ignore zero-length rows
+                if (row.size() > 0) {
+                    if (row_tally.find(row.size()) != row_tally.end()) {
+                        row_tally[row.size()]++;
+                    }
+                    else {
+                        row_tally[row.size()] = 1;
+                        row_when[row.size()] = i;
+                    }
                 }
             }
 

--- a/include/internal/csv_reader.cpp
+++ b/include/internal/csv_reader.cpp
@@ -435,7 +435,12 @@ namespace csv {
 
         while (!this->records.empty() && 
             this->records.front().size() != this->n_cols) {
-            this->records.pop_front();
+            if (!this->strict) {
+                this->records.pop_front();
+            }
+            else {
+                throw std::runtime_error("Line too short");
+            }
         }
 
         if (!this->records.empty()) {

--- a/include/internal/csv_reader.cpp
+++ b/include/internal/csv_reader.cpp
@@ -223,25 +223,14 @@ namespace csv {
          *  `end_feed()` should be called after the last string.
          */
         this->handle_unicode_bom(in);
-
-        try {
-            this->record_buffer = internals::parse({
-                in,
-                this->parse_flags,
-                this->ws_flags,
-                this->record_buffer,
-                this->format.strict,
-                this->records
-            });
-        }
-        catch (std::runtime_error& err) {
-            throw std::runtime_error("Unescaped single quote around line ");
-            
-            /** TODO: Add this back in+
-                std::to_string(this->num_rows) + " near:\n" +
-                std::string(in.substr(i, 100)));
-                */
-        }
+        this->record_buffer = internals::parse({
+            in,
+            this->parse_flags,
+            this->ws_flags,
+            this->record_buffer,
+            this->format.strict,
+            this->records
+        });
 
         if (!this->pre_header_trimmed) {
             for (int i = 0; i <= this->format.header && !this->records.empty(); i++) {

--- a/include/internal/csv_reader.hpp
+++ b/include/internal/csv_reader.hpp
@@ -31,7 +31,9 @@ namespace csv {
         std::string format_row(const std::vector<std::string>& row, csv::string_view delim = ", ");
     }
 
-    CSVGuessResult guess_format(csv::string_view filename, const std::vector<char>& delims);
+    /** Guess the delimiter used by a delimiter-separated values file */
+    CSVGuessResult guess_format(csv::string_view filename,
+        const std::vector<char>& delims = { ',', '|', '\t', ';', '^', '~' });
 
     /** @class CSVReader
      *  @brief Main class for parsing CSVs from files and in-memory sources

--- a/include/internal/csv_reader.hpp
+++ b/include/internal/csv_reader.hpp
@@ -90,7 +90,6 @@ namespace csv {
             }
 
             CONSTEXPR bool operator!=(const iterator& other) const { return !operator==(other); }
-
         private:
             CSVReader * daddy = nullptr;  // Pointer to parent
             CSVRow row;                   // Current row

--- a/include/internal/csv_reader.hpp
+++ b/include/internal/csv_reader.hpp
@@ -32,7 +32,7 @@ namespace csv {
     }
 
     std::vector<std::string> get_col_names(
-        const std::string& filename,
+        csv::string_view filename,
         const CSVFormat format = CSVFormat::guess_csv());
 
     /** Guess the delimiter used by a delimiter-separated values file */

--- a/include/internal/csv_reader.hpp
+++ b/include/internal/csv_reader.hpp
@@ -31,6 +31,8 @@ namespace csv {
         std::string format_row(const std::vector<std::string>& row, csv::string_view delim = ", ");
     }
 
+    CSVGuessResult guess_format(csv::string_view filename, const std::vector<char>& delims);
+
     /** @class CSVReader
      *  @brief Main class for parsing CSVs from files and in-memory sources
      *
@@ -231,42 +233,4 @@ namespace csv {
 
         /**@}*/ // End of parser internals
     };
-
-    namespace internals {
-        /** Class for guessing the delimiter & header row number of CSV files */
-        class CSVGuesser {
-
-            /** Private subclass of csv::CSVReader which performs statistics 
-             *  on row lengths
-             */
-            struct Guesser : public CSVReader {
-                using CSVReader::CSVReader;
-                void bad_row_handler(std::vector<std::string> record) override;
-                friend CSVGuesser;
-
-                // Frequency counter of row length
-                std::unordered_map<size_t, size_t> row_tally = { { 0, 0 } };
-
-                // Map row lengths to row num where they first occurred
-                std::unordered_map<size_t, size_t> row_when = { { 0, 0 } };
-            };
-
-        public:
-            CSVGuesser(csv::string_view _filename, const std::vector<char>& _delims) :
-                filename(_filename), delims(_delims) {};
-            CSVGuessResult guess_delim();
-            bool first_guess();
-            void second_guess();
-
-        private:
-            std::string filename;      /**< File to read */
-            std::string head;          /**< First x bytes of file */
-            std::vector<char> delims;  /**< Candidate delimiters */
-
-            char delim;                /**< Chosen delimiter (set by guess_delim()) */
-            int header_row = 0;        /**< Chosen header row (set by guess_delim()) */
-
-            void get_csv_head();       /**< Retrieve the first x bytes of a file */
-        };
-    }
 }

--- a/include/internal/csv_reader.hpp
+++ b/include/internal/csv_reader.hpp
@@ -184,18 +184,15 @@ namespace csv {
 
         /** @name CSV Settings **/
         ///@{
-        char delimiter;         /**< Delimiter character */
-        char quote_char;        /**< Quote character */
-        int header_row;         /**< Line number of the header row (zero-indexed) */
-        bool strict = false;    /**< Strictness of parser */
+        CSVFormat format;
 
         /** An array where the (i + 128)th slot gives the ParseFlags for ASCII character i */
-        std::array<internals::ParseFlags, 256> parse_flags;
+        internals::ParseFlagMap parse_flags;
 
         /** An array where the (i + 128)th slot determines whether ASCII character i should
          *  be trimmed
          */
-        std::array<bool, 256> ws_flags;
+        internals::WhitespaceMap ws_flags;
         ///@}
 
         /** @name Parser State */

--- a/include/internal/csv_reader.hpp
+++ b/include/internal/csv_reader.hpp
@@ -3,7 +3,7 @@
  */
 
 #pragma once
-#include <array>
+
 #include <deque>
 #include <iterator>
 #include <memory>
@@ -16,6 +16,7 @@
 #include "constants.hpp"
 #include "data_type.h"
 #include "csv_format.hpp"
+#include "csv_reader_internals.hpp"
 #include "csv_row.hpp"
 #include "compatibility.hpp"
 #include "row_buffer.hpp"
@@ -148,17 +149,6 @@ namespace csv {
          * @{
          */
 
-         /**  @typedef ParseFlags
-          *   An enum used for describing the significance of each character
-          *   with respect to CSV parsing
-          */
-        enum ParseFlags {
-            NOT_SPECIAL, /**< Characters with no special meaning */
-            QUOTE,       /**< Characters which may signify a quote escape */
-            DELIMITER,   /**< Characters which may signify a new field */
-            NEWLINE      /**< Characters which may signify a new row */
-        };
-
         /** A string buffer and its size. Consumed by read_csv_worker(). */
         using WorkItem = std::pair<std::unique_ptr<char[]>, size_t>;
 
@@ -168,20 +158,6 @@ namespace csv {
             std::mutex feed_lock; /**< Allow only one worker to write */
             std::condition_variable feed_cond; /**< Wake up worker */
         };
-
-        /** Create a vector v where each index i corresponds to the
-         *  ASCII number for a character and, v[i + 128] labels it according to
-         *  the CSVReader::ParseFlags enum
-         */
-        HEDLEY_CONST CONSTEXPR
-            std::array<CSVReader::ParseFlags, 256> make_parse_flags() const;
-
-        /** Create a vector v where each index i corresponds to the
-         *  ASCII number for a character c and, v[i + 128] is true if 
-         *  c is a whitespace character
-         */
-        HEDLEY_CONST CONSTEXPR
-            std::array<bool, 256> make_ws_flags(const char * delims, size_t n_chars) const;
 
         /** Open a file for reading. Implementation is compiler specific. */
         void fopen(csv::string_view filename);
@@ -218,7 +194,7 @@ namespace csv {
         bool strict = false;    /**< Strictness of parser */
 
         /** An array where the (i + 128)th slot gives the ParseFlags for ASCII character i */
-        std::array<ParseFlags, 256> parse_flags;
+        std::array<internals::ParseFlags, 256> parse_flags;
 
         /** An array where the (i + 128)th slot determines whether ASCII character i should
          *  be trimmed

--- a/include/internal/csv_reader.hpp
+++ b/include/internal/csv_reader.hpp
@@ -29,6 +29,9 @@ namespace csv {
     /** Stuff that is generally not of interest to end-users */
     namespace internals {
         std::string format_row(const std::vector<std::string>& row, csv::string_view delim = ", ");
+
+        std::vector<std::string> _get_col_names( csv::string_view head, const CSVFormat format = CSVFormat::guess_csv());
+        CSVGuessResult _guess_format(csv::string_view head, const std::vector<char>& delims = { ',', '|', '\t', ';', '^', '~' });
     }
 
     std::vector<std::string> get_col_names(

--- a/include/internal/csv_reader.hpp
+++ b/include/internal/csv_reader.hpp
@@ -210,7 +210,7 @@ namespace csv {
         /** @name Parser State */
         ///@{
         /** Pointer to a object containing column information */
-        internals::ColNamesPtr col_names = nullptr;
+        internals::ColNamesPtr col_names = std::make_shared<internals::ColNames>();
 
         /** Whether or not an attempt to find Unicode BOM has been made */
         bool unicode_bom_scan = false;

--- a/include/internal/csv_reader.hpp
+++ b/include/internal/csv_reader.hpp
@@ -179,15 +179,8 @@ namespace csv {
         /** Queue of parsed CSV rows */
         std::deque<CSVRow> records;
 
-        /** @name CSV Parsing Callbacks
-         *  The heart of the CSV parser.
-         *  These methods are called by feed().
-         */
-        ///@{
         /** Handles possible Unicode byte order mark */
         CONSTEXPR void handle_unicode_bom(csv::string_view& in);
-        virtual void bad_row_handler(std::vector<std::string>);
-        ///@}
 
         /** @name CSV Settings **/
         ///@{

--- a/include/internal/csv_reader.hpp
+++ b/include/internal/csv_reader.hpp
@@ -139,7 +139,6 @@ namespace csv {
         
         /** @name CSV Metadata: Attributes */
         ///@{
-        RowCount row_num = 0;        /**< How many lines have been parsed so far */
         RowCount correct_rows = 0;   /**< How many correct rows (minus header)
                                       *   have been parsed so far
                                       */
@@ -187,8 +186,6 @@ namespace csv {
          *  These methods are called by feed().
          */
         ///@{
-        void write_record();
-
         /** Handles possible Unicode byte order mark */
         CONSTEXPR void handle_unicode_bom(csv::string_view& in);
         virtual void bad_row_handler(std::vector<std::string>);

--- a/include/internal/csv_reader.hpp
+++ b/include/internal/csv_reader.hpp
@@ -146,8 +146,6 @@ namespace csv {
         ///@}
 
         void close();
-
-        friend CSVCollection parse(csv::string_view, CSVFormat);
     protected:
         /**
          * \defgroup csv_internal CSV Parser Internals

--- a/include/internal/csv_reader.hpp
+++ b/include/internal/csv_reader.hpp
@@ -218,6 +218,9 @@ namespace csv {
         /** Whether or not an attempt to find Unicode BOM has been made */
         bool unicode_bom_scan = false;
 
+        /** Whether or not rows before header were trimmed */
+        bool pre_header_trimmed = false;
+
         /** The number of columns in this CSV */
         size_t n_cols = 0;
         ///@}

--- a/include/internal/csv_reader.hpp
+++ b/include/internal/csv_reader.hpp
@@ -31,6 +31,10 @@ namespace csv {
         std::string format_row(const std::vector<std::string>& row, csv::string_view delim = ", ");
     }
 
+    std::vector<std::string> get_col_names(
+        const std::string& filename,
+        const CSVFormat format = CSVFormat::guess_csv());
+
     /** Guess the delimiter used by a delimiter-separated values file */
     CSVGuessResult guess_format(csv::string_view filename,
         const std::vector<char>& delims = { ',', '|', '\t', ';', '^', '~' });

--- a/include/internal/csv_reader.hpp
+++ b/include/internal/csv_reader.hpp
@@ -139,10 +139,10 @@ namespace csv {
         
         /** @name CSV Metadata: Attributes */
         ///@{
-        RowCount correct_rows = 0;   /**< How many correct rows (minus header)
-                                      *   have been parsed so far
-                                      */
-        bool utf8_bom = false;       /**< Set to true if UTF-8 BOM was detected */
+        RowCount num_rows = 0;   /**< How many rows (minus header)
+                                   *   have been parsed so far
+                                   */
+        bool utf8_bom = false;   /**< Set to true if UTF-8 BOM was detected */
         ///@}
 
         void close();
@@ -173,12 +173,6 @@ namespace csv {
         /** Returns true if we have reached end of file */
         bool eof() { return !(this->infile); };
 
-        /** Buffer for current row being parsed */
-        internals::BufferPtr record_buffer = internals::BufferPtr(new internals::RawRowBuffer());
-
-        /** Queue of parsed CSV rows */
-        std::deque<CSVRow> records;
-
         /** Handles possible Unicode byte order mark */
         CONSTEXPR void handle_unicode_bom(csv::string_view& in);
 
@@ -199,6 +193,12 @@ namespace csv {
         ///@{
         /** Pointer to a object containing column information */
         internals::ColNamesPtr col_names = std::make_shared<internals::ColNames>();
+
+        /** Buffer for current row being parsed */
+        internals::BufferPtr record_buffer = internals::BufferPtr(new internals::RawRowBuffer(this->col_names));
+
+        /** Queue of parsed CSV rows */
+        std::deque<CSVRow> records;
 
         /** Whether or not an attempt to find Unicode BOM has been made */
         bool unicode_bom_scan = false;

--- a/include/internal/csv_reader_internals.cpp
+++ b/include/internal/csv_reader_internals.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "csv_reader_internals.hpp"
 
 namespace csv {

--- a/include/internal/csv_reader_internals.cpp
+++ b/include/internal/csv_reader_internals.cpp
@@ -100,11 +100,9 @@ namespace csv {
                     // Case: Escaped quote
                     text_buffer += in[i];
 
+                    // Note: Unescaped single quotes can be handled by the parser
                     if (next_ch == ParseFlags::QUOTE)
                         ++i;  // Case: Two consecutive quotes
-                    else if (data.strict) {
-                        throw std::runtime_error("Unescaped single quote");
-                    }
 
                     break;
                 }

--- a/include/internal/csv_reader_internals.cpp
+++ b/include/internal/csv_reader_internals.cpp
@@ -1,0 +1,114 @@
+#pragma once
+#include "csv_reader_internals.hpp"
+
+namespace csv {
+    namespace internals {
+        CSV_INLINE BufferPtr parse(const ParseData& data) {
+            using internals::ParseFlags;
+
+            // TODO: Should this be an instance variable?
+            bool quote_escape = false;  // Are we currently in a quote escaped field?
+
+            // Optimizations
+            auto * HEDLEY_RESTRICT parse_flags = data.parse_flags.data();
+            auto * HEDLEY_RESTRICT ws_flags = data.ws_flags.data();
+            auto& in = data.in;
+            auto& row_buffer = *(data.row_buffer.get());
+            auto& text_buffer = row_buffer.buffer;
+            auto& split_buffer = row_buffer.split_buffer;
+            text_buffer.reserve(data.in.size());
+            split_buffer.reserve(data.in.size() / 10);
+
+            const size_t in_size = in.size();
+            for (size_t i = 0; i < in_size; i++) {
+                switch (parse_flags[data.in[i] + 128]) {
+                case ParseFlags::DELIMITER:
+                    if (!quote_escape) {
+                        split_buffer.push_back((unsigned short)row_buffer.size());
+                        break;
+                    }
+
+                    HEDLEY_FALL_THROUGH;
+                case ParseFlags::NEWLINE:
+                    if (!quote_escape) {
+                        // End of record -> Write record
+                        if (i + 1 < in_size && in[i + 1] == '\n') // Catches CRLF (or LFLF)
+                            ++i;
+
+                        data.write_record();
+                        break;
+                    }
+
+                    // Treat as regular character
+                    text_buffer += in[i];
+                    break;
+                case ParseFlags::NOT_SPECIAL: {
+                    size_t start, end;
+
+                    // Trim off leading whitespace
+                    while (i < in_size && ws_flags[in[i] + 128]) {
+                        i++;
+                    }
+
+                    start = i;
+
+                    // Optimization: Since NOT_SPECIAL characters tend to occur in contiguous
+                    // sequences, use the loop below to avoid having to go through the outer
+                    // switch statement as much as possible
+                    while (i + 1 < in_size
+                        && parse_flags[in[i + 1] + 128] == ParseFlags::NOT_SPECIAL) {
+                        i++;
+                    }
+
+                    // Trim off trailing whitespace
+                    end = i;
+                    while (ws_flags[in[end] + 128]) {
+                        end--;
+                    }
+
+                    // Finally append text
+#ifdef CSV_HAS_CXX17
+                    text_buffer += in.substr(start, end - start + 1);
+#else
+                    for (; start < end + 1; start++) {
+                        text_buffer += in[start];
+                    }
+#endif
+
+                    break;
+                }
+                default: // Quote
+                    if (!quote_escape) {
+                        // Don't deref past beginning
+                        if (i && parse_flags[in[i - 1] + 128] >= ParseFlags::DELIMITER) {
+                            // Case: Previous character was delimiter or newline
+                            quote_escape = true;
+                        }
+
+                        break;
+                    }
+
+                    auto next_ch = parse_flags[in[i + 1] + 128];
+                    if (next_ch >= ParseFlags::DELIMITER) {
+                        // Case: Delim or newline => end of field
+                        quote_escape = false;
+                        break;
+                    }
+
+                    // Case: Escaped quote
+                    text_buffer += in[i];
+
+                    if (next_ch == ParseFlags::QUOTE)
+                        ++i;  // Case: Two consecutive quotes
+                    else if (data.strict) {
+                        throw std::runtime_error("Unescaped single quote");
+                    }
+
+                    break;
+                }
+            }
+
+            return row_buffer.reset();
+        }
+    }
+}

--- a/include/internal/csv_reader_internals.cpp
+++ b/include/internal/csv_reader_internals.cpp
@@ -35,7 +35,9 @@ namespace csv {
                         if (i + 1 < in_size && in[i + 1] == '\n') // Catches CRLF (or LFLF)
                             ++i;
 
-                        data.write_record();
+                        // TODO: Refactor this
+                        // Make row_buffer spit out a CSVRow not the other way around
+                        data.records.push_back(CSVRow(data.row_buffer));
                         break;
                     }
 

--- a/include/internal/csv_reader_internals.cpp
+++ b/include/internal/csv_reader_internals.cpp
@@ -110,5 +110,23 @@ namespace csv {
 
             return row_buffer.reset();
         }
+
+        CSV_INLINE std::string get_csv_head(csv::string_view filename) {
+            const size_t bytes = 500000;
+            std::ifstream infile(filename.data());
+            if (!infile.is_open()) {
+                throw std::runtime_error("Cannot open file " + std::string(filename));
+            }
+
+            std::unique_ptr<char[]> buffer(new char[bytes + 1]);
+            char * head_buffer = buffer.get();
+
+            for (size_t i = 0; i < bytes + 1; i++) {
+                head_buffer[i] = '\0';
+            }
+
+            infile.read(head_buffer, bytes);
+            return std::string(head_buffer);
+        }
     }
 }

--- a/include/internal/csv_reader_internals.hpp
+++ b/include/internal/csv_reader_internals.hpp
@@ -1,11 +1,13 @@
 #pragma once
 #include <array>
+#include <deque>
 #include <functional>
 #include <fstream>
 #include <memory>
 #include <string>
 
 #include "compatibility.hpp"
+#include "csv_row.hpp"
 #include "row_buffer.hpp"
 
 namespace csv {
@@ -74,7 +76,7 @@ namespace csv {
             WhitespaceMap ws_flags;
             BufferPtr row_buffer;
             bool strict;
-            std::function<void()> write_record;
+            std::deque<CSVRow>& records;
         };
 
         CSV_INLINE BufferPtr parse(const ParseData& data);

--- a/include/internal/csv_reader_internals.hpp
+++ b/include/internal/csv_reader_internals.hpp
@@ -75,7 +75,6 @@ namespace csv {
             ParseFlagMap parse_flags;
             WhitespaceMap ws_flags;
             BufferPtr row_buffer;
-            bool strict;
             std::deque<CSVRow>& records;
         };
 

--- a/include/internal/csv_reader_internals.hpp
+++ b/include/internal/csv_reader_internals.hpp
@@ -1,6 +1,9 @@
 #pragma once
 #include <array>
 #include <functional>
+#include <fstream>
+#include <memory>
+#include <string>
 
 #include "compatibility.hpp"
 #include "row_buffer.hpp"
@@ -76,5 +79,8 @@ namespace csv {
 
         CSV_INLINE BufferPtr parse(const ParseData& data);
         CSV_INLINE void write_record(const ParseData& data);
+
+        /** Read the first 500KB of a CSV file */
+        CSV_INLINE std::string get_csv_head(csv::string_view filename);
     }
 }

--- a/include/internal/csv_reader_internals.hpp
+++ b/include/internal/csv_reader_internals.hpp
@@ -1,0 +1,61 @@
+#pragma once
+#include <array>
+
+namespace csv {
+    namespace internals {
+        /**  @typedef ParseFlags
+         *   An enum used for describing the significance of each character
+         *   with respect to CSV parsing
+         */
+        enum ParseFlags {
+            NOT_SPECIAL, /**< Characters with no special meaning */
+            QUOTE,       /**< Characters which may signify a quote escape */
+            DELIMITER,   /**< Characters which may signify a new field */
+            NEWLINE      /**< Characters which may signify a new row */
+        };
+
+        /** Create a vector v where each index i corresponds to the
+         *  ASCII number for a character and, v[i + 128] labels it according to
+         *  the CSVReader::ParseFlags enum
+         */
+        HEDLEY_CONST CONSTEXPR std::array<ParseFlags, 256> make_parse_flags(char delimiter, char quote_char) {
+            std::array<ParseFlags, 256> ret = {};
+            for (int i = -128; i < 128; i++) {
+                const int arr_idx = i + 128;
+                char ch = char(i);
+
+                if (ch == delimiter)
+                    ret[arr_idx] = DELIMITER;
+                else if (ch == quote_char)
+                    ret[arr_idx] = QUOTE;
+                else if (ch == '\r' || ch == '\n')
+                    ret[arr_idx] = NEWLINE;
+                else
+                    ret[arr_idx] = NOT_SPECIAL;
+            }
+
+            return ret;
+        }
+
+        /** Create a vector v where each index i corresponds to the
+         *  ASCII number for a character c and, v[i + 128] is true if
+         *  c is a whitespace character
+         */
+        HEDLEY_CONST CONSTEXPR std::array<bool, 256> make_ws_flags(const char * ws_chars, size_t n_chars) {
+            std::array<bool, 256> ret = {};
+            for (int i = -128; i < 128; i++) {
+                const int arr_idx = i + 128;
+                char ch = char(i);
+                ret[arr_idx] = false;
+
+                for (size_t j = 0; j < n_chars; j++) {
+                    if (ws_chars[j] == ch) {
+                        ret[arr_idx] = true;
+                    }
+                }
+            }
+
+            return ret;
+        }
+    }
+}

--- a/include/internal/csv_reader_internals.hpp
+++ b/include/internal/csv_reader_internals.hpp
@@ -75,6 +75,7 @@ namespace csv {
             ParseFlagMap parse_flags;
             WhitespaceMap ws_flags;
             BufferPtr row_buffer;
+            bool& quote_escape; /*< Whether or not we are currently in a quote escaped field */
             std::deque<CSVRow>& records;
         };
 

--- a/include/internal/csv_reader_iterator.cpp
+++ b/include/internal/csv_reader_iterator.cpp
@@ -7,6 +7,10 @@
 namespace csv {
     /** Return an iterator to the first row in the reader */
     CSV_INLINE CSVReader::iterator CSVReader::begin() {
+        if (this->records.empty()) {
+            this->read_csv();
+        }
+
         CSVReader::iterator ret(this, std::move(this->records.front()));
         this->records.pop_front();
         return ret;

--- a/include/internal/csv_row.cpp
+++ b/include/internal/csv_row.cpp
@@ -109,7 +109,7 @@ namespace csv {
         return std::reverse_iterator<CSVRow::iterator>(this->begin());
     }
 
-    CSV_INLINE unsigned short CSVRow::split_at(size_t n) const
+    CSV_INLINE size_t CSVRow::split_at(size_t n) const
     {
         return this->buffer->split_buffer[this->start + n];
     }

--- a/include/internal/csv_row.cpp
+++ b/include/internal/csv_row.cpp
@@ -16,11 +16,11 @@ namespace csv {
      *  std::runtime_error If n is out of bounds
      */
     CSV_INLINE csv::string_view CSVRow::get_string_view(size_t n) const {
-        csv::string_view ret(this->row_str);
+        csv::string_view ret(this->data.row_str);
 
         // First assume that field comprises entire row, then adjust accordingly
         size_t beg = 0,
-            end = row_str.size(),
+            end = this->data.row_str.size(),
             r_size = this->size();
 
         if (n >= r_size)
@@ -111,7 +111,7 @@ namespace csv {
 
     CSV_INLINE size_t CSVRow::split_at(size_t n) const
     {
-        return this->buffer->split_buffer[this->start + n];
+        return this->buffer->split_buffer[this->data.col_pos.start + n];
     }
 
     CSV_INLINE HEDLEY_NON_NULL(2)

--- a/include/internal/csv_row.cpp
+++ b/include/internal/csv_row.cpp
@@ -69,9 +69,10 @@ namespace csv {
      */
     CSV_INLINE CSVField CSVRow::operator[](const std::string& col_name) const {
         auto & col_names = this->buffer->col_names;
-        auto col_pos = col_names->col_pos.find(col_name);
-        if (col_pos != col_names->col_pos.end())
-            return this->operator[](col_pos->second);
+        auto col_pos = col_names->index_of(col_name);
+        if (col_pos > -1) {
+            return this->operator[](col_pos);
+        }
 
         throw std::runtime_error("Can't find a column named " + col_name);
     }

--- a/include/internal/csv_row.hpp
+++ b/include/internal/csv_row.hpp
@@ -184,13 +184,7 @@ namespace csv {
         CSVRow() = default;
         
         /** Construct a CSVRow from a RawRowBuffer */
-        CSVRow(const internals::BufferPtr& _buffer) : buffer(_buffer)
-        {
-            auto& row_data = _buffer->get_row();
-            this->row_str = row_data.row_str;
-            this->start = row_data.col_pos.start;
-            this->n_cols = row_data.col_pos.n_cols;
-        };
+        CSVRow(const internals::BufferPtr& _buffer) : buffer(_buffer), data(_buffer->get_row()) {};
 
         /** Constructor for testing */
         CSVRow(const std::string& str, const std::vector<unsigned short>& splits,
@@ -198,10 +192,10 @@ namespace csv {
             : CSVRow(internals::BufferPtr(new internals::RawRowBuffer(str, splits, col_names))) {};
 
         /** Indicates whether row is empty or not */
-        CONSTEXPR bool empty() const { return this->row_str.empty(); }
+        CONSTEXPR bool empty() const { return this->data.row_str.empty(); }
 
         /** Return the number of fields in this row */
-        CONSTEXPR size_t size() const { return this->n_cols; }
+        CONSTEXPR size_t size() const { return this->data.col_pos.n_cols; }
 
         /** @name Value Retrieval */
         ///@{
@@ -285,9 +279,7 @@ namespace csv {
         size_t split_at(size_t n) const;
 
         internals::BufferPtr buffer = nullptr; /**< Memory buffer containing data for this row. */
-        csv::string_view row_str = "";         /**< Text data for this row */
-        size_t start;                          /**< Where in split buffer this row begins */
-        size_t n_cols;                         /**< Numbers of columns this row has */
+        internals::RowData data;               /**< Contains row string and column positions. */
     };
 
 #pragma region CSVField::get Specializations

--- a/include/internal/csv_row.hpp
+++ b/include/internal/csv_row.hpp
@@ -183,15 +183,13 @@ namespace csv {
     public:
         CSVRow() = default;
         
-        // TODO: Remove this
-        /** Construct a CSVRow from a RawRowBuffer. Should be called by CSVReader::write_record. */
-        CSVRow(const internals::BufferPtr& _str) : buffer(_str)
+        /** Construct a CSVRow from a RawRowBuffer */
+        CSVRow(const internals::BufferPtr& _buffer) : buffer(_buffer)
         {
-            this->row_str = _str->get_row();
-
-            auto splits = _str->get_splits();
-            this->start = splits.start;
-            this->n_cols = splits.n_cols;
+            auto& row_data = _buffer->get_row();
+            this->row_str = row_data.row_str;
+            this->start = row_data.col_pos.start;
+            this->n_cols = row_data.col_pos.n_cols;
         };
 
         /** Constructor for testing */
@@ -284,12 +282,12 @@ namespace csv {
 
     private:
         /** Get the index in CSVRow's text buffer where the n-th field begins */
-        unsigned short split_at(size_t n) const;
+        size_t split_at(size_t n) const;
 
         internals::BufferPtr buffer = nullptr; /**< Memory buffer containing data for this row. */
         csv::string_view row_str = "";         /**< Text data for this row */
         size_t start;                          /**< Where in split buffer this row begins */
-        unsigned short n_cols;                 /**< Numbers of columns this row has */
+        size_t n_cols;                         /**< Numbers of columns this row has */
     };
 
 #pragma region CSVField::get Specializations

--- a/include/internal/csv_row.hpp
+++ b/include/internal/csv_row.hpp
@@ -183,6 +183,7 @@ namespace csv {
     public:
         CSVRow() = default;
         
+        // TODO: Remove this
         /** Construct a CSVRow from a RawRowBuffer. Should be called by CSVReader::write_record. */
         CSVRow(const internals::BufferPtr& _str) : buffer(_str)
         {

--- a/include/internal/csv_stat.cpp
+++ b/include/internal/csv_stat.cpp
@@ -113,7 +113,6 @@ namespace csv {
 
         auto current_record = this->records.begin();
         for (size_t processed = 0; current_record != this->records.end(); processed++) {
-            // TODO: Throw error if user requests it???
             if (current_record->size() == this->n_cols) {
                 auto current_field = (*current_record)[i];
 
@@ -131,6 +130,9 @@ namespace csv {
                     this->variance(x_n, i);
                     this->min_max(x_n, i);
                 }
+            }
+            else if (this->format.get_variable_column_policy() == VariableColumnPolicy::THROW) {
+                throw std::runtime_error("Line too short " + internals::format_row(*current_record));
             }
 
             ++current_record;

--- a/include/internal/csv_stat.cpp
+++ b/include/internal/csv_stat.cpp
@@ -132,7 +132,7 @@ namespace csv {
                 }
             }
             else if (this->format.get_variable_column_policy() == VariableColumnPolicy::THROW) {
-                throw std::runtime_error("Line too short " + internals::format_row(*current_record));
+                throw std::runtime_error("Line has different length than the others " + internals::format_row(*current_record));
             }
 
             ++current_record;

--- a/include/internal/csv_stat.cpp
+++ b/include/internal/csv_stat.cpp
@@ -113,21 +113,24 @@ namespace csv {
 
         auto current_record = this->records.begin();
         for (size_t processed = 0; current_record != this->records.end(); processed++) {
-            auto current_field = (*current_record)[i];
+            // TODO: Throw error if user requests it???
+            if (current_record->size() == this->n_cols) {
+                auto current_field = (*current_record)[i];
 
-            // Optimization: Don't count() if there's too many distinct values in the first 1000 rows
-            if (processed < 1000 || this->counts[i].size() <= 500)
-                this->count(current_field, i);
+                // Optimization: Don't count() if there's too many distinct values in the first 1000 rows
+                if (processed < 1000 || this->counts[i].size() <= 500)
+                    this->count(current_field, i);
 
-            this->dtype(current_field, i);
+                this->dtype(current_field, i);
 
-            // Numeric Stuff
-            if (current_field.is_num()) {
-                long double x_n = current_field.get<long double>();
+                // Numeric Stuff
+                if (current_field.is_num()) {
+                    long double x_n = current_field.get<long double>();
 
-                // This actually calculates mean AND variance
-                this->variance(x_n, i);
-                this->min_max(x_n, i);
+                    // This actually calculates mean AND variance
+                    this->variance(x_n, i);
+                    this->min_max(x_n, i);
+                }
             }
 
             ++current_record;

--- a/include/internal/csv_utility.cpp
+++ b/include/internal/csv_utility.cpp
@@ -9,11 +9,11 @@ namespace csv {
      *
      *  @snippet tests/test_read_csv.cpp Parse Example
      */
-    CSV_INLINE CSVCollection parse(csv::string_view in, CSVFormat format) {
+    CSV_INLINE CSVReader parse(csv::string_view in, CSVFormat format) {
         CSVReader parser(format);
         parser.feed(in);
         parser.end_feed();
-        return parser.records;
+        return parser;
     }
 
     /** Parse a RFC 4180 CSV string, returning a collection
@@ -23,7 +23,7 @@ namespace csv {
      *  @snippet tests/test_read_csv.cpp Escaped Comma
      *
      */
-    CSV_INLINE CSVCollection operator ""_csv(const char* in, size_t n) {
+    CSV_INLINE CSVReader operator ""_csv(const char* in, size_t n) {
         return parse(csv::string_view(in, n));
     }
 

--- a/include/internal/csv_utility.cpp
+++ b/include/internal/csv_utility.cpp
@@ -27,17 +27,6 @@ namespace csv {
         return parse(csv::string_view(in, n));
     }
 
-    /** Return a CSV's column names
-     *
-     *  @param[in] filename  Path to CSV file
-     *  @param[in] format    Format of the CSV file
-     *
-     */
-    CSV_INLINE std::vector<std::string> get_col_names(const std::string& filename, CSVFormat format) {
-        CSVReader reader(filename, format);
-        return reader.get_col_names();
-    }
-
     /**
      *  Find the position of a column in a CSV file or CSV_NOT_FOUND otherwise
      *

--- a/include/internal/csv_utility.cpp
+++ b/include/internal/csv_utility.cpp
@@ -48,11 +48,7 @@ namespace csv {
     CSV_INLINE CSVFileInfo get_file_info(const std::string& filename) {
         CSVReader reader(filename);
         CSVFormat format = reader.get_format();
-        for (auto& row : reader) {
-            #ifndef NDEBUG
-            SUPPRESS_UNUSED_WARNING(row);
-            #endif
-        }
+        for (auto it = reader.begin(); it != reader.end(); ++it);
 
         CSVFileInfo info = {
             filename,

--- a/include/internal/csv_utility.cpp
+++ b/include/internal/csv_utility.cpp
@@ -58,7 +58,7 @@ namespace csv {
             filename,
             reader.get_col_names(),
             format.get_delim(),
-            reader.correct_rows,
+            reader.num_rows,
             (int)reader.get_col_names().size()
         };
 

--- a/include/internal/csv_utility.hpp
+++ b/include/internal/csv_utility.hpp
@@ -21,8 +21,8 @@ namespace csv {
      *  @brief Convienience functions for parsing small strings
      */
      ///@{
-    CSVCollection operator ""_csv(const char*, size_t);
-    CSVCollection parse(csv::string_view in, CSVFormat format = CSVFormat());
+    CSVReader operator ""_csv(const char*, size_t);
+    CSVReader parse(csv::string_view in, CSVFormat format = CSVFormat());
     ///@}
 
     /** @name Utility Functions */

--- a/include/internal/csv_utility.hpp
+++ b/include/internal/csv_utility.hpp
@@ -29,8 +29,6 @@ namespace csv {
     ///@{
     std::unordered_map<std::string, DataType> csv_data_types(const std::string&);
     CSVFileInfo get_file_info(const std::string& filename);
-    CSVGuessResult guess_format(csv::string_view filename,
-        const std::vector<char>& delims = { ',', '|', '\t', ';', '^', '~' });
     std::vector<std::string> get_col_names(
         const std::string& filename,
         const CSVFormat format = CSVFormat::guess_csv());

--- a/include/internal/csv_utility.hpp
+++ b/include/internal/csv_utility.hpp
@@ -29,9 +29,6 @@ namespace csv {
     ///@{
     std::unordered_map<std::string, DataType> csv_data_types(const std::string&);
     CSVFileInfo get_file_info(const std::string& filename);
-    std::vector<std::string> get_col_names(
-        const std::string& filename,
-        const CSVFormat format = CSVFormat::guess_csv());
     int get_col_pos(const std::string filename, const std::string col_name,
         const CSVFormat format = CSVFormat::guess_csv());
     ///@}

--- a/include/internal/row_buffer.cpp
+++ b/include/internal/row_buffer.cpp
@@ -43,9 +43,11 @@ namespace csv {
         {
             const size_t head_idx = this->current_split_idx,
                 new_split_idx = this->split_buffer.size();
-         
+            unsigned short n_cols = (new_split_idx - head_idx > 0) ?
+                (unsigned short)(new_split_idx - head_idx + 1): 0;
+
             this->current_split_idx = new_split_idx;
-            return ColumnPositions(*this, head_idx, (unsigned short)(new_split_idx - head_idx + 1));
+            return ColumnPositions(*this, head_idx, n_cols);
         }
 
         CSV_INLINE size_t RawRowBuffer::size() const {

--- a/include/internal/row_buffer.cpp
+++ b/include/internal/row_buffer.cpp
@@ -25,10 +25,9 @@ namespace csv {
         CSV_INLINE int ColNames::index_of(csv::string_view col_name) const {
             auto pos = this->col_pos.find(col_name.data());
             if (pos != this->col_pos.end())
-                return pos->second;
+                return (int)pos->second;
 
-            // TODO: Change to a constant
-            return -1;
+            return CSV_NOT_FOUND;
         }
 
         CSV_INLINE size_t ColNames::size() const {

--- a/include/internal/row_buffer.cpp
+++ b/include/internal/row_buffer.cpp
@@ -35,10 +35,17 @@ namespace csv {
             return this->col_names.size();
         }
 
+        CSV_INLINE RowData RawRowBuffer::get_row() {
+            return {
+                this->get_row_string(),
+                this->get_splits()
+            };
+        }
+
         /** Get the current row in the buffer
          *  @note Has the side effect of updating the current end pointer
          */
-        CSV_INLINE csv::string_view RawRowBuffer::get_row() {
+        CSV_INLINE csv::string_view RawRowBuffer::get_row_string() {
             csv::string_view ret(
                 this->buffer.c_str() + this->current_end, // Beginning of string
                 (this->buffer.size() - this->current_end) // Count
@@ -56,7 +63,7 @@ namespace csv {
                 (unsigned short)(new_split_idx - head_idx + 1): 0;
 
             this->current_split_idx = new_split_idx;
-            return ColumnPositions(*this, head_idx, n_cols);
+            return ColumnPositions(head_idx, n_cols);
         }
 
         CSV_INLINE size_t RawRowBuffer::size() const {
@@ -88,10 +95,6 @@ namespace csv {
             // No need to remove unnecessary bits from this buffer
             // (memory savings would be marginal anyways)
             return new_buff;
-        }
-
-        CSV_INLINE unsigned short ColumnPositions::split_at(int n) const {
-            return this->parent->split_buffer[this->start + n];
         }
     }
 }

--- a/include/internal/row_buffer.cpp
+++ b/include/internal/row_buffer.cpp
@@ -10,16 +10,25 @@ namespace csv {
         //////////////
         // ColNames //
         //////////////
+        CSV_INLINE std::vector<std::string> ColNames::get_col_names() const {
+            return this->col_names;
+        }
 
-        CSV_INLINE ColNames::ColNames(const std::vector<std::string>& _cnames)
-            : col_names(_cnames) {
-            for (size_t i = 0; i < _cnames.size(); i++) {
-                this->col_pos[_cnames[i]] = i;
+        CSV_INLINE void ColNames::set_col_names(const std::vector<std::string>& cnames) {
+            this->col_names = cnames;
+
+            for (size_t i = 0; i < cnames.size(); i++) {
+                this->col_pos[cnames[i]] = i;
             }
         }
 
-        CSV_INLINE std::vector<std::string> ColNames::get_col_names() const {
-            return this->col_names;
+        CSV_INLINE int ColNames::index_of(csv::string_view col_name) const {
+            auto pos = this->col_pos.find(col_name.data());
+            if (pos != this->col_pos.end())
+                return pos->second;
+
+            // TODO: Change to a constant
+            return -1;
         }
 
         CSV_INLINE size_t ColNames::size() const {

--- a/include/internal/row_buffer.hpp
+++ b/include/internal/row_buffer.hpp
@@ -107,12 +107,15 @@ namespace csv {
         };
 
         struct ColumnPositions {
+            ColumnPositions() = default;
             constexpr ColumnPositions(size_t _start, unsigned short _size) : start(_start), n_cols(_size) {};
             size_t start;                /**< Where in split_buffer the array of column positions begins */
             size_t n_cols;               /**< Number of columns */
         };
 
         struct RowData {
+            RowData() = default;
+
             csv::string_view row_str;
             ColumnPositions col_pos;
         };

--- a/include/internal/row_buffer.hpp
+++ b/include/internal/row_buffer.hpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "compatibility.hpp" // For string view
+#include "constants.hpp"
 
 namespace csv {
     namespace internals {
@@ -40,6 +41,7 @@ namespace csv {
             void set_col_names(const std::vector<std::string>&);
             int index_of(csv::string_view) const;
 
+            bool empty() const { return this->col_names.empty(); }
             size_t size() const;
 
         private:

--- a/include/internal/row_buffer.hpp
+++ b/include/internal/row_buffer.hpp
@@ -69,6 +69,7 @@ namespace csv {
         class RawRowBuffer {
         public:
             RawRowBuffer() = default;
+            RawRowBuffer(const std::shared_ptr<ColNames>& _col_names) : col_names(_col_names) {};
 
             /** Constructor mainly used for testing
              *  @param[in] _buffer    CSV text without delimiters or newlines

--- a/include/internal/row_buffer.hpp
+++ b/include/internal/row_buffer.hpp
@@ -14,6 +14,7 @@
 namespace csv {
     namespace internals {
         class RawRowBuffer;
+        struct RowData;
         struct ColumnPositions;
         struct ColNames;
         using BufferPtr = std::shared_ptr<RawRowBuffer>;
@@ -80,9 +81,8 @@ namespace csv {
                 const std::shared_ptr<ColNames>& _col_names) :
                 buffer(_buffer), split_buffer(_splits), col_names(_col_names) {};
 
-            csv::string_view get_row();      /**< Return a string_view over the current_row */
-            ColumnPositions get_splits();    /**< Return the field start positions for the current row */
-
+            /** Return necessary information to construct a CSV row */
+            RowData get_row();
             size_t size() const;             /**< Return size of current row */
             size_t splits_size() const;      /**< Return (num columns - 1) for current row */
             BufferPtr reset() const;         /**< Create a new RawRowBuffer with this buffer's unfinished work */
@@ -99,21 +99,22 @@ namespace csv {
             ColNamesPtr col_names = nullptr; /**< Pointer to column names */
 
         private:
+            csv::string_view get_row_string();   /**< Return a string_view over the current_row */
+            ColumnPositions get_splits();        /**< Return the field start positions for the current row */
+
             size_t current_end = 0;          /**< Where we are currently in the text buffer */
             size_t current_split_idx = 0;    /**< Where we are currently in the split buffer */
         };
 
         struct ColumnPositions {
-            ColumnPositions() : parent(nullptr) {};
-            constexpr ColumnPositions(const RawRowBuffer& _parent,
-                size_t _start, unsigned short _size) : parent(&_parent), start(_start), n_cols(_size) {};
-
-            const RawRowBuffer * parent; /**< RawRowBuffer to grab data from */
+            constexpr ColumnPositions(size_t _start, unsigned short _size) : start(_start), n_cols(_size) {};
             size_t start;                /**< Where in split_buffer the array of column positions begins */
-            unsigned short n_cols;       /**< Number of columns */
+            size_t n_cols;               /**< Number of columns */
+        };
 
-            /// Get the n-th column index
-            unsigned short split_at(int n) const;
+        struct RowData {
+            csv::string_view row_str;
+            ColumnPositions col_pos;
         };
     }
 }

--- a/include/internal/row_buffer.hpp
+++ b/include/internal/row_buffer.hpp
@@ -29,12 +29,21 @@ namespace csv {
          *  allowing for indexing by column name.
          */
         struct ColNames {
-            ColNames(const std::vector<std::string>&);
-            std::vector<std::string> col_names;
-            std::unordered_map<std::string, size_t> col_pos;
+        public:
+            ColNames() = default;
+            ColNames(const std::vector<std::string>& names) {
+                set_col_names(names);
+            }
 
             std::vector<std::string> get_col_names() const;
+            void set_col_names(const std::vector<std::string>&);
+            int index_of(csv::string_view) const;
+
             size_t size() const;
+
+        private:
+            std::vector<std::string> col_names;
+            std::unordered_map<std::string, size_t> col_pos;
         };
 
         /** Class for reducing number of new string and new vector

--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -3840,8 +3840,6 @@ namespace csv {
     ///@{
     std::unordered_map<std::string, DataType> csv_data_types(const std::string&);
     CSVFileInfo get_file_info(const std::string& filename);
-    CSVGuessResult guess_format(csv::string_view filename,
-        const std::vector<char>& delims = { ',', '|', '\t', ';', '^', '~' });
     std::vector<std::string> get_col_names(
         const std::string& filename,
         const CSVFormat format = CSVFormat::guess_csv());
@@ -4217,7 +4215,9 @@ namespace csv {
         std::string format_row(const std::vector<std::string>& row, csv::string_view delim = ", ");
     }
 
-    CSVGuessResult guess_format(csv::string_view filename, const std::vector<char>& delims);
+    /** Guess the delimiter used by a delimiter-separated values file */
+    CSVGuessResult guess_format(csv::string_view filename,
+        const std::vector<char>& delims = { ',', '|', '\t', ';', '^', '~' });
 
     /** @class CSVReader
      *  @brief Main class for parsing CSVs from files and in-memory sources
@@ -4647,7 +4647,7 @@ namespace csv {
                 }
                 else {
                     row_tally[row.size()] = 1;
-                    row_when[row.size()] = i + 1;
+                    row_when[row.size()] = i;
                 }
             }
 
@@ -4657,15 +4657,7 @@ namespace csv {
                     const std::pair<size_t, size_t>& y) {
                 return x.second < y.second; });
 
-            // Idea: If CSV has leading comments, actual rows don't start
-            // until later and all actual rows get rejected because the CSV
-            // parser mistakenly uses the .size() of the comment rows to
-            // judge whether or not they are valid.
-            // 
-            // The first part of the if clause means we only change the header
-            // row if (number of rejected rows) > (number of actual rows)
-            if (max->second > rows.size() &&
-                (max->first > max_rlen)) {
+            if (max->first > max_rlen) {
                 max_rlen = max->first;
                 current_delim = cand_delim;
                 header = row_when[max_rlen];

--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -4965,7 +4965,11 @@ namespace csv {
             if (this->records.front().size() != this->n_cols &&
                 this->format.variable_column_policy != VariableColumnPolicy::KEEP) {
                 if (this->format.variable_column_policy == VariableColumnPolicy::THROW) {
-                    throw std::runtime_error("Line too short " + internals::format_row(this->records.front()));
+                    if (this->records.front().size() < this->n_cols) {
+                        throw std::runtime_error("Line too short " + internals::format_row(this->records.front()));
+                    }
+
+                    throw std::runtime_error("Line too long " + internals::format_row(this->records.front()));
                 }
 
                 // Silently drop row (default)
@@ -5738,7 +5742,7 @@ namespace csv {
                 }
             }
             else if (this->format.get_variable_column_policy() == VariableColumnPolicy::THROW) {
-                throw std::runtime_error("Line too short " + internals::format_row(*current_record));
+                throw std::runtime_error("Line has different length than the others " + internals::format_row(*current_record));
             }
 
             ++current_record;

--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -4347,20 +4347,6 @@ namespace csv {
             std::condition_variable feed_cond; /**< Wake up worker */
         };
 
-        /** Create a vector v where each index i corresponds to the
-         *  ASCII number for a character and, v[i + 128] labels it according to
-         *  the CSVReader::ParseFlags enum
-         */
-        HEDLEY_CONST CONSTEXPR
-            std::array<CSVReader::ParseFlags, 256> make_parse_flags() const;
-
-        /** Create a vector v where each index i corresponds to the
-         *  ASCII number for a character c and, v[i + 128] is true if 
-         *  c is a whitespace character
-         */
-        HEDLEY_CONST CONSTEXPR
-            std::array<bool, 256> make_ws_flags(const char * delims, size_t n_chars) const;
-
         /** Open a file for reading. Implementation is compiler specific. */
         void fopen(csv::string_view filename);
 

--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -4642,12 +4642,16 @@ namespace csv {
 
             for (size_t i = 0; i < rows.size(); i++) {
                 auto& row = rows[i];
-                if (row_tally.find(row.size()) != row_tally.end()) {
-                    row_tally[row.size()]++;
-                }
-                else {
-                    row_tally[row.size()] = 1;
-                    row_when[row.size()] = i;
+
+                // Ignore zero-length rows
+                if (row.size() > 0) {
+                    if (row_tally.find(row.size()) != row_tally.end()) {
+                        row_tally[row.size()]++;
+                    }
+                    else {
+                        row_tally[row.size()] = 1;
+                        row_when[row.size()] = i;
+                    }
                 }
             }
 

--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -5989,9 +5989,11 @@ namespace csv {
         {
             const size_t head_idx = this->current_split_idx,
                 new_split_idx = this->split_buffer.size();
-         
+            unsigned short n_cols = (new_split_idx - head_idx > 0) ?
+                (unsigned short)(new_split_idx - head_idx + 1): 0;
+
             this->current_split_idx = new_split_idx;
-            return ColumnPositions(*this, head_idx, (unsigned short)(new_split_idx - head_idx + 1));
+            return ColumnPositions(*this, head_idx, n_cols);
         }
 
         CSV_INLINE size_t RawRowBuffer::size() const {

--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -4837,7 +4837,7 @@ namespace csv {
             throw std::runtime_error("Unescaped single quote around line ");
             
             /** TODO: Add this back in+
-                std::to_string(this->correct_rows) + " near:\n" +
+                std::to_string(this->num_rows) + " near:\n" +
                 std::string(in.substr(i, 100)));
                 */
         }

--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -1,6 +1,6 @@
 #pragma once
 /*
-CSV for C++, version 2.0.0
+CSV for C++, version 1.6.0
 https://github.com/vincentlaucsb/csv-parser
 
 MIT License

--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -2871,9 +2871,6 @@ HEDLEY_DIAGNOSTIC_POP
 // takes precedence.
 // See: https://github.com/nemequ/hedley
 
-/** Used to supress unused variable warning in g++ */
-#define SUPPRESS_UNUSED_WARNING(x) (void)x
-
 namespace csv {
     /**
      *  @def IF_CONSTEXPR
@@ -2943,6 +2940,13 @@ namespace csv {
 namespace csv {
     class CSVReader;
 
+    /** Determines how to handle rows that are shorter or longer than the majority */
+    enum class VariableColumnPolicy {
+        THROW = -1,
+        IGNORE = 0,
+        KEEP   = 1
+    };
+
     /** Stores the inferred format of a CSV file. */
     struct CSVGuessResult {
         char delim;
@@ -2995,11 +2999,15 @@ namespace csv {
          */
         CSVFormat& header_row(int row);
 
-        /** Tells the parser to throw an std::runtime_error if an
-         *  invalid CSV sequence is found
-         */
-        CONSTEXPR CSVFormat& strict_parsing(bool is_strict = true) {
-            this->strict = is_strict;
+        /** Tells the parser how to handle columns of a different length than the others */
+        CONSTEXPR CSVFormat& variable_columns(VariableColumnPolicy policy = VariableColumnPolicy::IGNORE) {
+            this->variable_column_policy = policy;
+            return *this;
+        }
+
+        /** Tells the parser how to handle columns of a different length than the others */
+        CONSTEXPR CSVFormat& variable_columns(bool policy) {
+            this->variable_column_policy = (VariableColumnPolicy)policy;
             return *this;
         }
 
@@ -3010,7 +3018,7 @@ namespace csv {
         }
 
         #ifndef DOXYGEN_SHOULD_SKIP_THIS
-        char get_delim() {
+        char get_delim() const {
             // This error should never be received by end users.
             if (this->possible_delimiters.size() > 1) {
                 throw std::runtime_error("There is more than one possible delimiter.");
@@ -3019,13 +3027,10 @@ namespace csv {
             return this->possible_delimiters.at(0);
         }
 
-        std::vector<char> get_possible_delims() {
-            return this->possible_delimiters;
-        }
-
-        CONSTEXPR int get_header() {
-            return this->header;
-        }
+        CONSTEXPR int get_header() const { return this->header; }
+        std::vector<char> get_possible_delims() const { return this->possible_delimiters; }
+        std::vector<char> get_trim_chars() const { return this->trim_chars; }
+        CONSTEXPR VariableColumnPolicy get_variable_column_policy() const { return this->variable_column_policy; }
         #endif
         
         /** CSVFormat for guessing the delimiter */
@@ -3039,24 +3044,12 @@ namespace csv {
             return format;
         }
 
-        /** CSVFormat for strict RFC 4180 parsing */
-        CSV_INLINE static CSVFormat rfc4180_strict() {
-            CSVFormat format;
-            format.delimiter(',')
-                .quote('"')
-                .header_row(0)
-                .detect_bom(true)
-                .strict_parsing(true);
-
-            return format;
-        }
-
         bool guess_delim() {
             return this->possible_delimiters.size() > 1;
         }
 
         friend CSVReader;
-        friend std::vector<std::string> get_col_names(csv::string_view, CSVFormat);
+
     private:
         /**< Throws an error if delimiters and trim characters overlap */
         void assert_no_char_overlap();
@@ -3067,17 +3060,17 @@ namespace csv {
         /**< Set of whitespace characters to trim */
         std::vector<char> trim_chars = {};
 
-        /**< Quote character */
-        char quote_char = '"';
-
         /**< Row number with columns (ignored if col_names is non-empty) */
         int header = 0;
+
+        /**< Quote character */
+        char quote_char = '"';
 
         /**< Should be left empty unless file doesn't include header */
         std::vector<std::string> col_names = {};
 
-        /**< RFC 4180 non-compliance -> throw an error */
-        bool strict = false;
+        /**< Allow variable length columns? */
+        VariableColumnPolicy variable_column_policy = VariableColumnPolicy::IGNORE;
 
         /**< Detect and strip out Unicode byte order marks */
         bool unicode_detect = true;
@@ -3583,123 +3576,6 @@ namespace csv {
     }
 }
 /** @file
- *  Defines an object which can store CSV data in
- *  continuous regions of memory
- */
-
-#include <memory>
-#include <vector>
-#include <unordered_map>
-#include <string>
-
-
-namespace csv {
-    namespace internals {
-        class RawRowBuffer;
-        struct ColumnPositions;
-        struct ColNames;
-        using BufferPtr = std::shared_ptr<RawRowBuffer>;
-        using ColNamesPtr = std::shared_ptr<ColNames>;
-        using StrBufferPos = unsigned short;
-        using SplitArray = std::vector<StrBufferPos>;
-
-        /** @struct ColNames
-         *  A data structure for handling column name information.
-         *
-         *  These are created by CSVReader and passed (via smart pointer)
-         *  to CSVRow objects it creates, thus
-         *  allowing for indexing by column name.
-         */
-        struct ColNames {
-        public:
-            ColNames() = default;
-            ColNames(const std::vector<std::string>& names) {
-                set_col_names(names);
-            }
-
-            std::vector<std::string> get_col_names() const;
-            void set_col_names(const std::vector<std::string>&);
-            int index_of(csv::string_view) const;
-
-            size_t size() const;
-
-        private:
-            std::vector<std::string> col_names;
-            std::unordered_map<std::string, size_t> col_pos;
-        };
-
-        /** Class for reducing number of new string and new vector
-         *  and malloc calls
-         *
-         *  @par Motivation
-         *  By storing CSV strings in a giant string (as opposed to an
-         *  `std::vector` of smaller strings), we vastly reduce the number
-         *  of calls to `malloc()`, thus speeding up the program.
-         *  However, by doing so we will need a way to tell where different
-         *  fields are located within this giant string.
-         *  Hence, an array of indices is also maintained.
-         *
-         *  @warning
-         *  `reset()` should be called somewhat often in the code. Since each
-         *  `csv::CSVRow` contains an `std::shared_ptr` to a RawRowBuffer,
-         *  the buffers do not get deleted until every CSVRow referencing it gets
-         *  deleted. If RawRowBuffers get very large, then so will memory consumption.
-         *  Currently, `reset()` is called by `csv::CSVReader::feed()` at the end of 
-         *  every sequence of bytes parsed.
-         *  
-         */
-        class RawRowBuffer {
-        public:
-            RawRowBuffer() = default;
-
-            /** Constructor mainly used for testing
-             *  @param[in] _buffer    CSV text without delimiters or newlines
-             *  @param[in] _splits    Positions in buffer where CSV fields begin
-             *  @param[in] _col_names Pointer to a vector of column names
-             */
-            RawRowBuffer(const std::string& _buffer, const std::vector<StrBufferPos>& _splits,
-                const std::shared_ptr<ColNames>& _col_names) :
-                buffer(_buffer), split_buffer(_splits), col_names(_col_names) {};
-
-            csv::string_view get_row();      /**< Return a string_view over the current_row */
-            ColumnPositions get_splits();    /**< Return the field start positions for the current row */
-
-            size_t size() const;             /**< Return size of current row */
-            size_t splits_size() const;      /**< Return (num columns - 1) for current row */
-            BufferPtr reset() const;         /**< Create a new RawRowBuffer with this buffer's unfinished work */
-
-            /*
-             * TODO: Investigate performance benefits by storing a row's text right next to its 
-             * split_buffer. This would take greater advantage of locality, but would require a reworking
-             * of this data structure.
-             */
-
-            std::string buffer;              /**< Buffer for storing text */
-            SplitArray split_buffer = {};    /**< Array for storing indices (in buffer)
-                                                  of where CSV fields start */
-            ColNamesPtr col_names = nullptr; /**< Pointer to column names */
-
-        private:
-            size_t current_end = 0;          /**< Where we are currently in the text buffer */
-            size_t current_split_idx = 0;    /**< Where we are currently in the split buffer */
-        };
-
-        struct ColumnPositions {
-            ColumnPositions() : parent(nullptr) {};
-            constexpr ColumnPositions(const RawRowBuffer& _parent,
-                size_t _start, unsigned short _size) : parent(&_parent), start(_start), n_cols(_size) {};
-
-            const RawRowBuffer * parent; /**< RawRowBuffer to grab data from */
-            size_t start;                /**< Where in split_buffer the array of column positions begins */
-            unsigned short n_cols;       /**< Number of columns */
-
-            /// Get the n-th column index
-            unsigned short split_at(int n) const;
-        };
-    }
-}
-
-/** @file
  *  Defines CSV global constants
  */
 
@@ -3735,8 +3611,11 @@ namespace csv {
         /** For functions that lazy load a large CSV, this determines how
          *  many bytes are read at a time
          */
-        const size_t ITERATION_CHUNK_SIZE = 50000000; // 50MB
+        constexpr size_t ITERATION_CHUNK_SIZE = 50000000; // 50MB
     }
+
+    /** Integer indicating a requested column wasn't found. */
+    constexpr int CSV_NOT_FOUND = -1;
 
     /** Used for counting number of rows */
     using RowCount = long long int;
@@ -3779,6 +3658,128 @@ namespace csv {
             static_assert(std::is_floating_point<T>::value, "T must be a floating point type.");
             return std::abs(a - b) < epsilon;
         }
+    }
+}
+/** @file
+ *  Defines an object which can store CSV data in
+ *  continuous regions of memory
+ */
+
+#include <memory>
+#include <vector>
+#include <unordered_map>
+#include <string>
+
+
+namespace csv {
+    namespace internals {
+        class RawRowBuffer;
+        struct RowData;
+        struct ColumnPositions;
+        struct ColNames;
+        using BufferPtr = std::shared_ptr<RawRowBuffer>;
+        using ColNamesPtr = std::shared_ptr<ColNames>;
+        using StrBufferPos = unsigned short;
+        using SplitArray = std::vector<StrBufferPos>;
+
+        /** @struct ColNames
+         *  A data structure for handling column name information.
+         *
+         *  These are created by CSVReader and passed (via smart pointer)
+         *  to CSVRow objects it creates, thus
+         *  allowing for indexing by column name.
+         */
+        struct ColNames {
+        public:
+            ColNames() = default;
+            ColNames(const std::vector<std::string>& names) {
+                set_col_names(names);
+            }
+
+            std::vector<std::string> get_col_names() const;
+            void set_col_names(const std::vector<std::string>&);
+            int index_of(csv::string_view) const;
+
+            bool empty() const { return this->col_names.empty(); }
+            size_t size() const;
+
+        private:
+            std::vector<std::string> col_names;
+            std::unordered_map<std::string, size_t> col_pos;
+        };
+
+        /** Class for reducing number of new string and new vector
+         *  and malloc calls
+         *
+         *  @par Motivation
+         *  By storing CSV strings in a giant string (as opposed to an
+         *  `std::vector` of smaller strings), we vastly reduce the number
+         *  of calls to `malloc()`, thus speeding up the program.
+         *  However, by doing so we will need a way to tell where different
+         *  fields are located within this giant string.
+         *  Hence, an array of indices is also maintained.
+         *
+         *  @warning
+         *  `reset()` should be called somewhat often in the code. Since each
+         *  `csv::CSVRow` contains an `std::shared_ptr` to a RawRowBuffer,
+         *  the buffers do not get deleted until every CSVRow referencing it gets
+         *  deleted. If RawRowBuffers get very large, then so will memory consumption.
+         *  Currently, `reset()` is called by `csv::CSVReader::feed()` at the end of 
+         *  every sequence of bytes parsed.
+         *  
+         */
+        class RawRowBuffer {
+        public:
+            RawRowBuffer() = default;
+            RawRowBuffer(const std::shared_ptr<ColNames>& _col_names) : col_names(_col_names) {};
+
+            /** Constructor mainly used for testing
+             *  @param[in] _buffer    CSV text without delimiters or newlines
+             *  @param[in] _splits    Positions in buffer where CSV fields begin
+             *  @param[in] _col_names Pointer to a vector of column names
+             */
+            RawRowBuffer(const std::string& _buffer, const std::vector<StrBufferPos>& _splits,
+                const std::shared_ptr<ColNames>& _col_names) :
+                buffer(_buffer), split_buffer(_splits), col_names(_col_names) {};
+
+            /** Return necessary information to construct a CSV row */
+            RowData get_row();
+            size_t size() const;             /**< Return size of current row */
+            size_t splits_size() const;      /**< Return (num columns - 1) for current row */
+            BufferPtr reset() const;         /**< Create a new RawRowBuffer with this buffer's unfinished work */
+
+            /*
+             * TODO: Investigate performance benefits by storing a row's text right next to its 
+             * split_buffer. This would take greater advantage of locality, but would require a reworking
+             * of this data structure.
+             */
+
+            std::string buffer;              /**< Buffer for storing text */
+            SplitArray split_buffer = {};    /**< Array for storing indices (in buffer)
+                                                  of where CSV fields start */
+            ColNamesPtr col_names = nullptr; /**< Pointer to column names */
+
+        private:
+            csv::string_view get_row_string();   /**< Return a string_view over the current_row */
+            ColumnPositions get_splits();        /**< Return the field start positions for the current row */
+
+            size_t current_end = 0;          /**< Where we are currently in the text buffer */
+            size_t current_split_idx = 0;    /**< Where we are currently in the split buffer */
+        };
+
+        struct ColumnPositions {
+            ColumnPositions() = default;
+            constexpr ColumnPositions(size_t _start, unsigned short _size) : start(_start), n_cols(_size) {};
+            size_t start;                /**< Where in split_buffer the array of column positions begins */
+            size_t n_cols;               /**< Number of columns */
+        };
+
+        struct RowData {
+            RowData() = default;
+
+            csv::string_view row_str;
+            ColumnPositions col_pos;
+        };
     }
 }
 /** @file
@@ -3961,15 +3962,8 @@ namespace csv {
     public:
         CSVRow() = default;
         
-        /** Construct a CSVRow from a RawRowBuffer. Should be called by CSVReader::write_record. */
-        CSVRow(const internals::BufferPtr& _str) : buffer(_str)
-        {
-            this->row_str = _str->get_row();
-
-            auto splits = _str->get_splits();
-            this->start = splits.start;
-            this->n_cols = splits.n_cols;
-        };
+        /** Construct a CSVRow from a RawRowBuffer */
+        CSVRow(const internals::BufferPtr& _buffer) : buffer(_buffer), data(_buffer->get_row()) {};
 
         /** Constructor for testing */
         CSVRow(const std::string& str, const std::vector<unsigned short>& splits,
@@ -3977,10 +3971,10 @@ namespace csv {
             : CSVRow(internals::BufferPtr(new internals::RawRowBuffer(str, splits, col_names))) {};
 
         /** Indicates whether row is empty or not */
-        CONSTEXPR bool empty() const { return this->row_str.empty(); }
+        CONSTEXPR bool empty() const { return this->data.row_str.empty(); }
 
         /** Return the number of fields in this row */
-        CONSTEXPR size_t size() const { return this->n_cols; }
+        CONSTEXPR size_t size() const { return this->data.col_pos.n_cols; }
 
         /** @name Value Retrieval */
         ///@{
@@ -4061,12 +4055,10 @@ namespace csv {
 
     private:
         /** Get the index in CSVRow's text buffer where the n-th field begins */
-        unsigned short split_at(size_t n) const;
+        size_t split_at(size_t n) const;
 
         internals::BufferPtr buffer = nullptr; /**< Memory buffer containing data for this row. */
-        csv::string_view row_str = "";         /**< Text data for this row */
-        size_t start;                          /**< Where in split buffer this row begins */
-        unsigned short n_cols;                 /**< Numbers of columns this row has */
+        internals::RowData data;               /**< Contains row string and column positions. */
     };
 
 #pragma region CSVField::get Specializations
@@ -4188,7 +4180,7 @@ namespace csv {
             ParseFlagMap parse_flags;
             WhitespaceMap ws_flags;
             BufferPtr row_buffer;
-            bool strict;
+            bool& quote_escape; /*< Whether or not we are currently in a quote escaped field */
             std::deque<CSVRow>& records;
         };
 
@@ -4216,12 +4208,12 @@ namespace csv {
 
 /** The all encompassing namespace */
 namespace csv {
-    /** Integer indicating a requested column wasn't found. */
-    constexpr int CSV_NOT_FOUND = -1;
-
     /** Stuff that is generally not of interest to end-users */
     namespace internals {
         std::string format_row(const std::vector<std::string>& row, csv::string_view delim = ", ");
+
+        std::vector<std::string> _get_col_names( csv::string_view head, const CSVFormat format = CSVFormat::guess_csv());
+        CSVGuessResult _guess_format(csv::string_view head, const std::vector<char>& delims = { ',', '|', '\t', ';', '^', '~' });
     }
 
     std::vector<std::string> get_col_names(
@@ -4283,7 +4275,6 @@ namespace csv {
             }
 
             CONSTEXPR bool operator!=(const iterator& other) const { return !operator==(other); }
-
         private:
             CSVReader * daddy = nullptr;  // Pointer to parent
             CSVRow row;                   // Current row
@@ -4332,10 +4323,10 @@ namespace csv {
         
         /** @name CSV Metadata: Attributes */
         ///@{
-        RowCount correct_rows = 0;   /**< How many correct rows (minus header)
-                                      *   have been parsed so far
-                                      */
-        bool utf8_bom = false;       /**< Set to true if UTF-8 BOM was detected */
+        RowCount num_rows = 0;   /**< How many rows (minus header)
+                                   *   have been parsed so far
+                                   */
+        bool utf8_bom = false;   /**< Set to true if UTF-8 BOM was detected */
         ///@}
 
         void close();
@@ -4353,8 +4344,8 @@ namespace csv {
         /** Multi-threaded Reading State, including synchronization objects that cannot be moved. */
         struct ThreadedReadingState {
             std::deque<WorkItem> feed_buffer;    /**< Message queue for worker */
-            std::mutex feed_lock; /**< Allow only one worker to write */
-            std::condition_variable feed_cond; /**< Wake up worker */
+            std::mutex feed_lock;                /**< Allow only one worker to write */
+            std::condition_variable feed_cond;   /**< Wake up worker */
         };
 
         /** Open a file for reading. Implementation is compiler specific. */
@@ -4366,36 +4357,17 @@ namespace csv {
         /** Returns true if we have reached end of file */
         bool eof() { return !(this->infile); };
 
-        /** Buffer for current row being parsed */
-        internals::BufferPtr record_buffer = internals::BufferPtr(new internals::RawRowBuffer());
-
-        /** Queue of parsed CSV rows */
-        std::deque<CSVRow> records;
-
-        /** @name CSV Parsing Callbacks
-         *  The heart of the CSV parser.
-         *  These methods are called by feed().
-         */
-        ///@{
-        /** Handles possible Unicode byte order mark */
-        CONSTEXPR void handle_unicode_bom(csv::string_view& in);
-        virtual void bad_row_handler(std::vector<std::string>);
-        ///@}
-
         /** @name CSV Settings **/
         ///@{
-        char delimiter;         /**< Delimiter character */
-        char quote_char;        /**< Quote character */
-        int header_row;         /**< Line number of the header row (zero-indexed) */
-        bool strict = false;    /**< Strictness of parser */
+        CSVFormat format;
 
         /** An array where the (i + 128)th slot gives the ParseFlags for ASCII character i */
-        std::array<internals::ParseFlags, 256> parse_flags;
+        internals::ParseFlagMap parse_flags;
 
         /** An array where the (i + 128)th slot determines whether ASCII character i should
          *  be trimmed
          */
-        std::array<bool, 256> ws_flags;
+        internals::WhitespaceMap ws_flags;
         ///@}
 
         /** @name Parser State */
@@ -4403,11 +4375,20 @@ namespace csv {
         /** Pointer to a object containing column information */
         internals::ColNamesPtr col_names = std::make_shared<internals::ColNames>();
 
+        /** Buffer for current row being parsed */
+        internals::BufferPtr record_buffer = internals::BufferPtr(new internals::RawRowBuffer(this->col_names));
+
+        /** Queue of parsed CSV rows */
+        std::deque<CSVRow> records;
+
+        /** Whether or not we are in a quote-escaped field */
+        bool quote_escape = false;
+
         /** Whether or not an attempt to find Unicode BOM has been made */
         bool unicode_bom_scan = false;
 
         /** Whether or not rows before header were trimmed */
-        bool pre_header_trimmed = false;
+        bool header_trimmed = false;
 
         /** The number of columns in this CSV */
         size_t n_cols = 0;
@@ -4422,9 +4403,8 @@ namespace csv {
 
         /** @name Multi-Threaded File Reading: Flags and State */
         ///@{
-        std::FILE* HEDLEY_RESTRICT
-            infile = nullptr;                /**< Current file handle.
-                                                  Destroyed by ~CSVReader(). */
+        /** Current file handle. Destroyed by ~CSVReader(). */
+        std::FILE* HEDLEY_RESTRICT infile = nullptr;
         std::unique_ptr<ThreadedReadingState> feed_state;
         ///@} 
 
@@ -4594,6 +4574,100 @@ namespace csv {
 
             return ret.str();
         }
+
+        /** Return a CSV's column names
+         *
+         *  @param[in] filename  Path to CSV file
+         *  @param[in] format    Format of the CSV file
+         *
+         */
+        CSV_INLINE std::vector<std::string> _get_col_names(csv::string_view head, CSVFormat format) {
+            // Parse the CSV
+            auto buffer_ptr = internals::BufferPtr(new internals::RawRowBuffer());
+            auto trim_chars = format.get_trim_chars();
+
+            std::deque<CSVRow> rows;
+            bool quote_escape = false;
+
+            internals::parse({
+                head,
+                internals::make_parse_flags(format.get_delim(), '"'),
+                internals::make_ws_flags(trim_chars.data(), trim_chars.size()),
+                buffer_ptr,
+                quote_escape,
+                rows
+            });
+
+            return rows[format.get_header()];
+        }
+
+        /** Guess the delimiter used by a delimiter-separated values file */
+        CSV_INLINE CSVGuessResult _guess_format(csv::string_view head, const std::vector<char>& delims) {
+            /** For each delimiter, find out which row length was most common.
+                 *  The delimiter with the longest mode row length wins.
+                 *  Then, the line number of the header row is the first row with
+                 *  the mode row length.
+                 */
+
+            CSVFormat format;
+            size_t max_rlen = 0,
+                header = 0;
+            char current_delim = delims[0];
+
+            for (char cand_delim : delims) {
+                // Frequency counter of row length
+                std::unordered_map<size_t, size_t> row_tally = { { 0, 0 } };
+
+                // Map row lengths to row num where they first occurred
+                std::unordered_map<size_t, size_t> row_when = { { 0, 0 } };
+
+                format.delimiter(cand_delim);
+
+                // Parse the CSV
+                auto buffer_ptr = internals::BufferPtr(new internals::RawRowBuffer());
+                std::deque<CSVRow> rows;
+                bool quote_escape = false;
+
+                internals::parse({
+                    head,
+                    internals::make_parse_flags(cand_delim, '"'),
+                    internals::make_ws_flags({}, 0),
+                    buffer_ptr,
+                    quote_escape,
+                    rows
+                });
+
+                for (size_t i = 0; i < rows.size(); i++) {
+                    auto& row = rows[i];
+
+                    // Ignore zero-length rows
+                    if (row.size() > 0) {
+                        if (row_tally.find(row.size()) != row_tally.end()) {
+                            row_tally[row.size()]++;
+                        }
+                        else {
+                            row_tally[row.size()] = 1;
+                            row_when[row.size()] = i;
+                        }
+                    }
+                }
+
+                // Most common row length
+                auto max = std::max_element(row_tally.begin(), row_tally.end(),
+                    [](const std::pair<size_t, size_t>& x,
+                        const std::pair<size_t, size_t>& y) {
+                    return x.second < y.second; });
+
+                if (max->first > max_rlen) {
+                    max_rlen = max->first;
+                    current_delim = cand_delim;
+                    header = row_when[max_rlen];
+                }
+            }
+
+            return { current_delim, (int)header };
+        }
+
     }
 
     /** Return a CSV's column names
@@ -4605,129 +4679,30 @@ namespace csv {
     CSV_INLINE std::vector<std::string> get_col_names(csv::string_view filename, CSVFormat format) {
         auto head = internals::get_csv_head(filename);
 
-        // TODO: Refactor
-
         /** Guess delimiter and header row */
         if (format.guess_delim()) {
-            auto guess_result = guess_format(filename, format.possible_delimiters);
-            format.delimiter(guess_result.delim);
-            format.header = guess_result.header_row;
+            auto guess_result = guess_format(filename, format.get_possible_delims());
+            format.delimiter(guess_result.delim).header_row(guess_result.header_row);
         }
 
-        // Parse the CSV
-        auto buffer_ptr = internals::BufferPtr(new internals::RawRowBuffer());
-        std::deque<CSVRow> rows;
-
-        internals::parse({
-            head,
-            internals::make_parse_flags(format.get_delim(), '"'),
-            internals::make_ws_flags(format.trim_chars.data(), format.trim_chars.size()),
-            buffer_ptr,
-            false,
-            rows
-        });
-
-        return rows[format.header];
+        return internals::_get_col_names(head, format);
     }
 
     /** Guess the delimiter used by a delimiter-separated values file */
     CSV_INLINE CSVGuessResult guess_format(csv::string_view filename, const std::vector<char>& delims) {
         auto head = internals::get_csv_head(filename);
-
-        /** For each delimiter, find out which row length was most common.
-             *  The delimiter with the longest mode row length wins.
-             *  Then, the line number of the header row is the first row with
-             *  the mode row length.
-             */
-
-        CSVFormat format;
-        size_t max_rlen = 0,
-               header = 0;
-        char current_delim = delims[0];
-
-        for (char cand_delim : delims) {
-            // Frequency counter of row length
-            std::unordered_map<size_t, size_t> row_tally = { { 0, 0 } };
-
-            // Map row lengths to row num where they first occurred
-            std::unordered_map<size_t, size_t> row_when = { { 0, 0 } };
-
-            format.delimiter(cand_delim);
-
-            // Parse the CSV
-            auto buffer_ptr = internals::BufferPtr(new internals::RawRowBuffer());
-            std::deque<CSVRow> rows;
-
-            internals::parse({
-                head,
-                internals::make_parse_flags(cand_delim, '"'),
-                internals::make_ws_flags({}, 0),
-                buffer_ptr,
-                false,
-                rows
-            });
-
-            for (size_t i = 0; i < rows.size(); i++) {
-                auto& row = rows[i];
-
-                // Ignore zero-length rows
-                if (row.size() > 0) {
-                    if (row_tally.find(row.size()) != row_tally.end()) {
-                        row_tally[row.size()]++;
-                    }
-                    else {
-                        row_tally[row.size()] = 1;
-                        row_when[row.size()] = i;
-                    }
-                }
-            }
-
-            // Most common row length
-            auto max = std::max_element(row_tally.begin(), row_tally.end(),
-                [](const std::pair<size_t, size_t>& x,
-                    const std::pair<size_t, size_t>& y) {
-                return x.second < y.second; });
-
-            if (max->first > max_rlen) {
-                max_rlen = max->first;
-                current_delim = cand_delim;
-                header = row_when[max_rlen];
-            }
-        }
-
-        return { current_delim, (int)header };
+        return internals::_guess_format(head, delims);
     }
 
-    CSV_INLINE void CSVReader::bad_row_handler(std::vector<std::string> record) {
-        /** Handler for rejected rows (too short or too long). This does nothing
-         *  unless strict parsing was set, in which case it throws an eror.
-         *  Subclasses of CSVReader may easily override this to provide
-         *  custom behavior.
-         */
-        if (this->strict) {
-            std::string problem;
-            if (record.size() > this->col_names->size()) problem = "too long";
-            else problem = "too short";
-
-            throw std::runtime_error("Line " + problem + " around line " +
-                std::to_string(correct_rows) + " near\n" +
-                internals::format_row(record)
-            );
-        }
-    };
-
     /** Allows parsing in-memory sources (by calling feed() and end_feed()). */
-    CSV_INLINE CSVReader::CSVReader(CSVFormat format) :
-        delimiter(format.get_delim()), quote_char(format.quote_char),
-        header_row(format.header), strict(format.strict),
+    CSV_INLINE CSVReader::CSVReader(CSVFormat format) : 
         unicode_bom_scan(!format.unicode_detect), feed_state(new ThreadedReadingState)  {
-        this->record_buffer->col_names = this->col_names;
-
         if (!format.col_names.empty()) {
             this->set_col_names(format.col_names);
         }
         
-        parse_flags = internals::make_parse_flags(this->delimiter, this->quote_char);
+        this->format = format;
+        parse_flags = internals::make_parse_flags(format.get_delim(), format.quote_char);
         ws_flags = internals::make_ws_flags(format.trim_chars.data(), format.trim_chars.size());
     };
 
@@ -4746,28 +4721,24 @@ namespace csv {
      *
      */
     CSV_INLINE CSVReader::CSVReader(csv::string_view filename, CSVFormat format) : feed_state(new ThreadedReadingState) {
-        this->record_buffer->col_names = this->col_names;
+        auto head = internals::get_csv_head(filename);
 
         /** Guess delimiter and header row */
         if (format.guess_delim()) {
-            auto guess_result = guess_format(filename, format.possible_delimiters);
+            auto guess_result = internals::_guess_format(head, format.possible_delimiters);
             format.delimiter(guess_result.delim);
             format.header = guess_result.header_row;
         }
 
-        if (!format.col_names.empty()) {
-            this->set_col_names(format.col_names);
+        if (format.col_names.empty()) {
+            this->set_col_names(internals::_get_col_names(head, format));
         }
         else {
-            this->set_col_names(csv::get_col_names(filename, format));
+            this->set_col_names(format.col_names);
         }
 
-        header_row = format.header;
-        delimiter = format.get_delim();
-        quote_char = format.quote_char;
-        strict = format.strict;
-
-        parse_flags = internals::make_parse_flags(delimiter, quote_char);
+        this->format = format;
+        parse_flags = internals::make_parse_flags(format.get_delim(), format.quote_char);
         ws_flags = internals::make_ws_flags(format.trim_chars.data(), format.trim_chars.size());
 
         this->fopen(filename);
@@ -4775,17 +4746,15 @@ namespace csv {
 
     /** Return the format of the original raw CSV */
     CSV_INLINE CSVFormat CSVReader::get_format() const {
-        CSVFormat format;
-        format.delimiter(this->delimiter)
-            .quote(this->quote_char);
+        CSVFormat new_format = this->format;
 
         // Since users are normally not allowed to set 
         // column names and header row simulatenously,
         // we will set the backing variables directly here
-        format.col_names = this->col_names->get_col_names();
-        format.header = this->header_row;
+        new_format.col_names = this->col_names->get_col_names();
+        new_format.header = this->format.header;
 
-        return format;
+        return new_format;
     }
 
     /** Return the CSV's column names as a vector of strings. */
@@ -4812,46 +4781,44 @@ namespace csv {
         this->feed( csv::string_view(buff.first.get(), buff.second) );
     }
 
+    /** Parse a CSV-formatted string.
+     *
+     *  @par Usage
+     *  Incomplete CSV fragments can be joined together by calling feed() on them sequentially.
+     *
+     *  @note
+     *  `end_feed()` should be called after the last string.
+     */
     CSV_INLINE void CSVReader::feed(csv::string_view in) {
-        /** Parse a CSV-formatted string.
-         *
-         *  @par Usage
-         *  Incomplete CSV fragments can be joined together by calling feed() on them sequentially.
-         *  
-         *  @note
-         *  `end_feed()` should be called after the last string.
-         */
-        this->handle_unicode_bom(in);
+        /** Handle possible Unicode byte order mark */
+        if (!this->unicode_bom_scan) {
+            if (in[0] == '\xEF' && in[1] == '\xBB' && in[2] == '\xBF') {
+                in.remove_prefix(3); // Remove BOM from input string
+                this->utf8_bom = true;
+            }
 
-        try {
-            this->record_buffer = internals::parse({
-                in,
-                this->parse_flags,
-                this->ws_flags,
-                this->record_buffer,
-                this->strict,
-                this->records
-            });
-        }
-        catch (std::runtime_error& err) {
-            throw std::runtime_error("Unescaped single quote around line ");
-            
-            /** TODO: Add this back in+
-                std::to_string(this->num_rows) + " near:\n" +
-                std::string(in.substr(i, 100)));
-                */
+            this->unicode_bom_scan = true;
         }
 
-        if (!this->pre_header_trimmed) {
-            for (int i = 0; i <= this->header_row && !this->records.empty(); i++) {
-                if (i == this->header_row && this->col_names->get_col_names().empty()) {
+        this->record_buffer = internals::parse({
+            in,
+            this->parse_flags,
+            this->ws_flags,
+            this->record_buffer,
+            this->quote_escape,
+            this->records
+        });
+
+        if (!this->header_trimmed) {
+            for (int i = 0; i <= this->format.header && !this->records.empty(); i++) {
+                if (i == this->format.header && this->col_names->empty()) {
                     this->set_col_names(this->records.front());
                 }
 
                 this->records.pop_front();
             }
 
-            this->pre_header_trimmed = true;
+            this->header_trimmed = true;
         }
     }
 
@@ -4859,24 +4826,15 @@ namespace csv {
         /** Indicate that there is no more data to receive,
          *  and handle the last row
          */
-        this->records.push_back(CSVRow(this->record_buffer));
-    }
-
-    CONSTEXPR void CSVReader::handle_unicode_bom(csv::string_view& in) {
-        if (!this->unicode_bom_scan) {
-            if (in[0] == '\xEF' && in[1] == '\xBB' && in[2] == '\xBF') {            
-                in.remove_prefix(3); // Remove BOM from input string
-                this->utf8_bom = true;
-            }
-
-            this->unicode_bom_scan = true;
+        if (this->record_buffer->size() > 0) {
+            this->records.push_back(CSVRow(this->record_buffer));
         }
     }
 
+    /** Worker thread for read_csv() which parses CSV rows (while the main
+     *  thread pulls data from disk)
+     */
     CSV_INLINE void CSVReader::read_csv_worker() {
-        /** Worker thread for read_csv() which parses CSV rows (while the main
-         *         thread pulls data from disk)
-         */
         while (true) {
             std::unique_lock<std::mutex> lock{ this->feed_state->feed_lock }; // Get lock
             this->feed_state->feed_cond.wait(lock,                            // Wait
@@ -5003,23 +4961,24 @@ namespace csv {
             else return false; // Stop reading
         }
 
-        while (!this->records.empty() && 
-            this->records.front().size() != this->n_cols) {
-            if (!this->strict) {
+        while (!this->records.empty()) {
+            if (this->records.front().size() != this->n_cols &&
+                this->format.variable_column_policy != VariableColumnPolicy::KEEP) {
+                if (this->format.variable_column_policy == VariableColumnPolicy::THROW) {
+                    throw std::runtime_error("Line too short " + internals::format_row(this->records.front()));
+                }
+
+                // Silently drop row (default)
                 this->records.pop_front();
             }
             else {
-                throw std::runtime_error("Line too short");
+                row = std::move(this->records.front());
+                this->num_rows++;
+                this->records.pop_front();
+                return true;
             }
         }
-
-        if (!this->records.empty()) {
-            row = std::move(this->records.front());
-            this->correct_rows++;
-            this->records.pop_front();
-            return true;
-        }
-
+    
         return false;
     }
 }
@@ -5028,9 +4987,6 @@ namespace csv {
     namespace internals {
         CSV_INLINE BufferPtr parse(const ParseData& data) {
             using internals::ParseFlags;
-
-            // TODO: Should this be an instance variable?
-            bool quote_escape = false;  // Are we currently in a quote escaped field?
 
             // Optimizations
             auto * HEDLEY_RESTRICT parse_flags = data.parse_flags.data();
@@ -5046,20 +5002,18 @@ namespace csv {
             for (size_t i = 0; i < in_size; i++) {
                 switch (parse_flags[data.in[i] + 128]) {
                 case ParseFlags::DELIMITER:
-                    if (!quote_escape) {
+                    if (!data.quote_escape) {
                         split_buffer.push_back((unsigned short)row_buffer.size());
                         break;
                     }
 
                     HEDLEY_FALL_THROUGH;
                 case ParseFlags::NEWLINE:
-                    if (!quote_escape) {
+                    if (!data.quote_escape) {
                         // End of record -> Write record
                         if (i + 1 < in_size && in[i + 1] == '\n') // Catches CRLF (or LFLF)
                             ++i;
 
-                        // TODO: Refactor this
-                        // Make row_buffer spit out a CSVRow not the other way around
                         data.records.push_back(CSVRow(data.row_buffer));
                         break;
                     }
@@ -5103,11 +5057,11 @@ namespace csv {
                     break;
                 }
                 default: // Quote
-                    if (!quote_escape) {
+                    if (!data.quote_escape) {
                         // Don't deref past beginning
                         if (i && parse_flags[in[i - 1] + 128] >= ParseFlags::DELIMITER) {
                             // Case: Previous character was delimiter or newline
-                            quote_escape = true;
+                            data.quote_escape = true;
                         }
 
                         break;
@@ -5116,18 +5070,16 @@ namespace csv {
                     auto next_ch = parse_flags[in[i + 1] + 128];
                     if (next_ch >= ParseFlags::DELIMITER) {
                         // Case: Delim or newline => end of field
-                        quote_escape = false;
+                        data.quote_escape = false;
                         break;
                     }
 
                     // Case: Escaped quote
                     text_buffer += in[i];
 
+                    // Note: Unescaped single quotes can be handled by the parser
                     if (next_ch == ParseFlags::QUOTE)
                         ++i;  // Case: Two consecutive quotes
-                    else if (data.strict) {
-                        throw std::runtime_error("Unescaped single quote");
-                    }
 
                     break;
                 }
@@ -5227,11 +5179,11 @@ namespace csv {
      *  std::runtime_error If n is out of bounds
      */
     CSV_INLINE csv::string_view CSVRow::get_string_view(size_t n) const {
-        csv::string_view ret(this->row_str);
+        csv::string_view ret(this->data.row_str);
 
         // First assume that field comprises entire row, then adjust accordingly
         size_t beg = 0,
-            end = row_str.size(),
+            end = this->data.row_str.size(),
             r_size = this->size();
 
         if (n >= r_size)
@@ -5320,9 +5272,9 @@ namespace csv {
         return std::reverse_iterator<CSVRow::iterator>(this->begin());
     }
 
-    CSV_INLINE unsigned short CSVRow::split_at(size_t n) const
+    CSV_INLINE size_t CSVRow::split_at(size_t n) const
     {
-        return this->buffer->split_buffer[this->start + n];
+        return this->buffer->split_buffer[this->data.col_pos.start + n];
     }
 
     CSV_INLINE HEDLEY_NON_NULL(2)
@@ -5767,21 +5719,26 @@ namespace csv {
 
         auto current_record = this->records.begin();
         for (size_t processed = 0; current_record != this->records.end(); processed++) {
-            auto current_field = (*current_record)[i];
+            if (current_record->size() == this->n_cols) {
+                auto current_field = (*current_record)[i];
 
-            // Optimization: Don't count() if there's too many distinct values in the first 1000 rows
-            if (processed < 1000 || this->counts[i].size() <= 500)
-                this->count(current_field, i);
+                // Optimization: Don't count() if there's too many distinct values in the first 1000 rows
+                if (processed < 1000 || this->counts[i].size() <= 500)
+                    this->count(current_field, i);
 
-            this->dtype(current_field, i);
+                this->dtype(current_field, i);
 
-            // Numeric Stuff
-            if (current_field.is_num()) {
-                long double x_n = current_field.get<long double>();
+                // Numeric Stuff
+                if (current_field.is_num()) {
+                    long double x_n = current_field.get<long double>();
 
-                // This actually calculates mean AND variance
-                this->variance(x_n, i);
-                this->min_max(x_n, i);
+                    // This actually calculates mean AND variance
+                    this->variance(x_n, i);
+                    this->min_max(x_n, i);
+                }
+            }
+            else if (this->format.get_variable_column_policy() == VariableColumnPolicy::THROW) {
+                throw std::runtime_error("Line too short " + internals::format_row(*current_record));
             }
 
             ++current_record;
@@ -5947,17 +5904,13 @@ namespace csv {
     CSV_INLINE CSVFileInfo get_file_info(const std::string& filename) {
         CSVReader reader(filename);
         CSVFormat format = reader.get_format();
-        for (auto& row : reader) {
-            #ifndef NDEBUG
-            SUPPRESS_UNUSED_WARNING(row);
-            #endif
-        }
+        for (auto it = reader.begin(); it != reader.end(); ++it);
 
         CSVFileInfo info = {
             filename,
             reader.get_col_names(),
             format.get_delim(),
-            reader.correct_rows,
+            reader.num_rows,
             (int)reader.get_col_names().size()
         };
 
@@ -5990,20 +5943,26 @@ namespace csv {
         CSV_INLINE int ColNames::index_of(csv::string_view col_name) const {
             auto pos = this->col_pos.find(col_name.data());
             if (pos != this->col_pos.end())
-                return pos->second;
+                return (int)pos->second;
 
-            // TODO: Change to a constant
-            return -1;
+            return CSV_NOT_FOUND;
         }
 
         CSV_INLINE size_t ColNames::size() const {
             return this->col_names.size();
         }
 
+        CSV_INLINE RowData RawRowBuffer::get_row() {
+            return {
+                this->get_row_string(),
+                this->get_splits()
+            };
+        }
+
         /** Get the current row in the buffer
          *  @note Has the side effect of updating the current end pointer
          */
-        CSV_INLINE csv::string_view RawRowBuffer::get_row() {
+        CSV_INLINE csv::string_view RawRowBuffer::get_row_string() {
             csv::string_view ret(
                 this->buffer.c_str() + this->current_end, // Beginning of string
                 (this->buffer.size() - this->current_end) // Count
@@ -6021,7 +5980,7 @@ namespace csv {
                 (unsigned short)(new_split_idx - head_idx + 1): 0;
 
             this->current_split_idx = new_split_idx;
-            return ColumnPositions(*this, head_idx, n_cols);
+            return ColumnPositions(head_idx, n_cols);
         }
 
         CSV_INLINE size_t RawRowBuffer::size() const {
@@ -6053,10 +6012,6 @@ namespace csv {
             // No need to remove unnecessary bits from this buffer
             // (memory savings would be marginal anyways)
             return new_buff;
-        }
-
-        CSV_INLINE unsigned short ColumnPositions::split_at(int n) const {
-            return this->parent->split_buffer[this->start + n];
         }
     }
 }

--- a/single_include_test/csv.hpp
+++ b/single_include_test/csv.hpp
@@ -3840,8 +3840,6 @@ namespace csv {
     ///@{
     std::unordered_map<std::string, DataType> csv_data_types(const std::string&);
     CSVFileInfo get_file_info(const std::string& filename);
-    CSVGuessResult guess_format(csv::string_view filename,
-        const std::vector<char>& delims = { ',', '|', '\t', ';', '^', '~' });
     std::vector<std::string> get_col_names(
         const std::string& filename,
         const CSVFormat format = CSVFormat::guess_csv());
@@ -4217,7 +4215,9 @@ namespace csv {
         std::string format_row(const std::vector<std::string>& row, csv::string_view delim = ", ");
     }
 
-    CSVGuessResult guess_format(csv::string_view filename, const std::vector<char>& delims);
+    /** Guess the delimiter used by a delimiter-separated values file */
+    CSVGuessResult guess_format(csv::string_view filename,
+        const std::vector<char>& delims = { ',', '|', '\t', ';', '^', '~' });
 
     /** @class CSVReader
      *  @brief Main class for parsing CSVs from files and in-memory sources
@@ -4647,7 +4647,7 @@ namespace csv {
                 }
                 else {
                     row_tally[row.size()] = 1;
-                    row_when[row.size()] = i + 1;
+                    row_when[row.size()] = i;
                 }
             }
 
@@ -4657,15 +4657,7 @@ namespace csv {
                     const std::pair<size_t, size_t>& y) {
                 return x.second < y.second; });
 
-            // Idea: If CSV has leading comments, actual rows don't start
-            // until later and all actual rows get rejected because the CSV
-            // parser mistakenly uses the .size() of the comment rows to
-            // judge whether or not they are valid.
-            // 
-            // The first part of the if clause means we only change the header
-            // row if (number of rejected rows) > (number of actual rows)
-            if (max->second > rows.size() &&
-                (max->first > max_rlen)) {
+            if (max->first > max_rlen) {
                 max_rlen = max->first;
                 current_delim = cand_delim;
                 header = row_when[max_rlen];

--- a/single_include_test/csv.hpp
+++ b/single_include_test/csv.hpp
@@ -4965,7 +4965,11 @@ namespace csv {
             if (this->records.front().size() != this->n_cols &&
                 this->format.variable_column_policy != VariableColumnPolicy::KEEP) {
                 if (this->format.variable_column_policy == VariableColumnPolicy::THROW) {
-                    throw std::runtime_error("Line too short " + internals::format_row(this->records.front()));
+                    if (this->records.front().size() < this->n_cols) {
+                        throw std::runtime_error("Line too short " + internals::format_row(this->records.front()));
+                    }
+
+                    throw std::runtime_error("Line too long " + internals::format_row(this->records.front()));
                 }
 
                 // Silently drop row (default)
@@ -5738,7 +5742,7 @@ namespace csv {
                 }
             }
             else if (this->format.get_variable_column_policy() == VariableColumnPolicy::THROW) {
-                throw std::runtime_error("Line too short " + internals::format_row(*current_record));
+                throw std::runtime_error("Line has different length than the others " + internals::format_row(*current_record));
             }
 
             ++current_record;

--- a/single_include_test/csv.hpp
+++ b/single_include_test/csv.hpp
@@ -4347,20 +4347,6 @@ namespace csv {
             std::condition_variable feed_cond; /**< Wake up worker */
         };
 
-        /** Create a vector v where each index i corresponds to the
-         *  ASCII number for a character and, v[i + 128] labels it according to
-         *  the CSVReader::ParseFlags enum
-         */
-        HEDLEY_CONST CONSTEXPR
-            std::array<CSVReader::ParseFlags, 256> make_parse_flags() const;
-
-        /** Create a vector v where each index i corresponds to the
-         *  ASCII number for a character c and, v[i + 128] is true if 
-         *  c is a whitespace character
-         */
-        HEDLEY_CONST CONSTEXPR
-            std::array<bool, 256> make_ws_flags(const char * delims, size_t n_chars) const;
-
         /** Open a file for reading. Implementation is compiler specific. */
         void fopen(csv::string_view filename);
 

--- a/single_include_test/csv.hpp
+++ b/single_include_test/csv.hpp
@@ -4642,12 +4642,16 @@ namespace csv {
 
             for (size_t i = 0; i < rows.size(); i++) {
                 auto& row = rows[i];
-                if (row_tally.find(row.size()) != row_tally.end()) {
-                    row_tally[row.size()]++;
-                }
-                else {
-                    row_tally[row.size()] = 1;
-                    row_when[row.size()] = i;
+
+                // Ignore zero-length rows
+                if (row.size() > 0) {
+                    if (row_tally.find(row.size()) != row_tally.end()) {
+                        row_tally[row.size()]++;
+                    }
+                    else {
+                        row_tally[row.size()] = 1;
+                        row_when[row.size()] = i;
+                    }
                 }
             }
 

--- a/single_include_test/csv.hpp
+++ b/single_include_test/csv.hpp
@@ -5989,9 +5989,11 @@ namespace csv {
         {
             const size_t head_idx = this->current_split_idx,
                 new_split_idx = this->split_buffer.size();
-         
+            unsigned short n_cols = (new_split_idx - head_idx > 0) ?
+                (unsigned short)(new_split_idx - head_idx + 1): 0;
+
             this->current_split_idx = new_split_idx;
-            return ColumnPositions(*this, head_idx, (unsigned short)(new_split_idx - head_idx + 1));
+            return ColumnPositions(*this, head_idx, n_cols);
         }
 
         CSV_INLINE size_t RawRowBuffer::size() const {

--- a/single_include_test/csv.hpp
+++ b/single_include_test/csv.hpp
@@ -1,6 +1,6 @@
 #pragma once
 /*
-CSV for C++, version 2.0.0
+CSV for C++, version 1.6.0
 https://github.com/vincentlaucsb/csv-parser
 
 MIT License

--- a/single_include_test/csv.hpp
+++ b/single_include_test/csv.hpp
@@ -3661,7 +3661,7 @@ namespace csv {
                 const std::shared_ptr<ColNames>& _col_names) :
                 buffer(_buffer), split_buffer(_splits), col_names(_col_names) {};
 
-            csv::string_view get_row();      /**< Return a string_view over the current_row */
+            csv::string_view get_row_string();      /**< Return a string_view over the current_row */
             ColumnPositions get_splits();    /**< Return the field start positions for the current row */
 
             size_t size() const;             /**< Return size of current row */
@@ -3964,7 +3964,7 @@ namespace csv {
         /** Construct a CSVRow from a RawRowBuffer. Should be called by CSVReader::write_record. */
         CSVRow(const internals::BufferPtr& _str) : buffer(_str)
         {
-            this->row_str = _str->get_row();
+            this->row_str = _str->get_row_string();
 
             auto splits = _str->get_splits();
             this->start = splits.start;
@@ -6003,7 +6003,7 @@ namespace csv {
         /** Get the current row in the buffer
          *  @note Has the side effect of updating the current end pointer
          */
-        CSV_INLINE csv::string_view RawRowBuffer::get_row() {
+        CSV_INLINE csv::string_view RawRowBuffer::get_row_string() {
             csv::string_view ret(
                 this->buffer.c_str() + this->current_end, // Beginning of string
                 (this->buffer.size() - this->current_end) // Count

--- a/single_include_test/csv.hpp
+++ b/single_include_test/csv.hpp
@@ -4332,7 +4332,7 @@ namespace csv {
         
         /** @name CSV Metadata: Attributes */
         ///@{
-        RowCount correct_rows = 0;   /**< How many correct rows (minus header)
+        RowCount num_rows = 0;   /**< How many correct rows (minus header)
                                       *   have been parsed so far
                                       */
         bool utf8_bom = false;       /**< Set to true if UTF-8 BOM was detected */
@@ -4710,7 +4710,7 @@ namespace csv {
             else problem = "too short";
 
             throw std::runtime_error("Line " + problem + " around line " +
-                std::to_string(correct_rows) + " near\n" +
+                std::to_string(num_rows) + " near\n" +
                 internals::format_row(record)
             );
         }
@@ -4837,7 +4837,7 @@ namespace csv {
             throw std::runtime_error("Unescaped single quote around line ");
             
             /** TODO: Add this back in+
-                std::to_string(this->correct_rows) + " near:\n" +
+                std::to_string(this->num_rows) + " near:\n" +
                 std::string(in.substr(i, 100)));
                 */
         }
@@ -5015,7 +5015,7 @@ namespace csv {
 
         if (!this->records.empty()) {
             row = std::move(this->records.front());
-            this->correct_rows++;
+            this->num_rows++;
             this->records.pop_front();
             return true;
         }
@@ -5957,7 +5957,7 @@ namespace csv {
             filename,
             reader.get_col_names(),
             format.get_delim(),
-            reader.correct_rows,
+            reader.num_rows,
             (int)reader.get_col_names().size()
         };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ target_sources(csv_test
         test_csv_buffer.cpp
         test_csv_field.cpp
         test_csv_format.cpp
-        #test_csv_iterator.cpp
+        test_csv_iterator.cpp
         test_csv_row.cpp
         test_csv_row_json.cpp
         #test_csv_stat.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,7 +12,7 @@ target_sources(csv_test
         test_csv_row_json.cpp
         #test_csv_stat.cpp
         test_guess_csv.cpp
-        #test_read_csv.cpp
+        test_read_csv.cpp
         test_read_csv_file.cpp
         test_write_csv.cpp
         test_data_type.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,12 +7,13 @@ target_sources(csv_test
         test_csv_buffer.cpp
         test_csv_field.cpp
         test_csv_format.cpp
-        test_csv_iterator.cpp
+        #test_csv_iterator.cpp
         test_csv_row.cpp
         test_csv_row_json.cpp
-        test_csv_stat.cpp
+        #test_csv_stat.cpp
         test_guess_csv.cpp
-        test_read_csv.cpp
+        #test_read_csv.cpp
+        test_read_csv_file.cpp
         test_write_csv.cpp
         test_data_type.cpp
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(csv_test
         test_csv_row.cpp
         test_csv_row_json.cpp
         test_csv_stat.cpp
+        test_guess_csv.cpp
         test_read_csv.cpp
         test_write_csv.cpp
         test_data_type.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ target_sources(csv_test
         test_csv_iterator.cpp
         test_csv_row.cpp
         test_csv_row_json.cpp
-        #test_csv_stat.cpp
+        test_csv_stat.cpp
         test_guess_csv.cpp
         test_read_csv.cpp
         test_read_csv_file.cpp

--- a/tests/test_csv_buffer.cpp
+++ b/tests/test_csv_buffer.cpp
@@ -57,7 +57,7 @@ TEST_CASE("GiantSplitBufferTest", "[test_giant_split_buffer]") {
         splits->push_back(2);
         splits->push_back(3);
 
-        auto pos = buffer->get_row().col_pos;
+        pos = buffer->get_row().col_pos;
         REQUIRE(split_at(buffer, pos, 0) == 1);
         REQUIRE(split_at(buffer, pos, 1) == 2);
         REQUIRE(split_at(buffer, pos, 2) == 3);

--- a/tests/test_csv_buffer.cpp
+++ b/tests/test_csv_buffer.cpp
@@ -4,18 +4,22 @@
 #include "csv.hpp"
 using namespace csv::internals;
 
+size_t split_at(BufferPtr buffer, ColumnPositions pos, int n) {
+    return buffer->split_buffer[pos.start + n];
+}
+
 TEST_CASE("GiantStringBufferTest", "[test_giant_string_buffer]") {
     BufferPtr buffer = BufferPtr(new RawRowBuffer());
 
     buffer->buffer.append("1234");
-    std::string first_row = std::string(buffer->get_row());
+    std::string first_row = std::string(buffer->get_row().row_str);
 
     buffer->buffer.append("5678");
-    std::string second_row = std::string(buffer->get_row());
+    std::string second_row = std::string(buffer->get_row().row_str);
 
     buffer = buffer->reset();
     buffer->buffer.append("abcd");
-    std::string third_row = std::string(buffer->get_row());
+    std::string third_row = std::string(buffer->get_row().row_str);
 
     REQUIRE(first_row == "1234");
     REQUIRE(second_row == "5678");
@@ -30,19 +34,19 @@ TEST_CASE("GiantSplitBufferTest", "[test_giant_split_buffer]") {
     splits->push_back(2);
     splits->push_back(3);
 
-    auto pos = buffer->get_splits();
-    REQUIRE(pos.split_at(0) == 1);
-    REQUIRE(pos.split_at(1) == 2);
-    REQUIRE(pos.split_at(2) == 3);
+    auto pos = buffer->get_row().col_pos;
+    REQUIRE(split_at(buffer, pos, 0) == 1);
+    REQUIRE(split_at(buffer, pos, 1) == 2);
+    REQUIRE(split_at(buffer, pos, 2) == 3);
     REQUIRE(pos.n_cols == 4);
 
     SECTION("Two Splits Test") {
         splits->push_back(4);
         splits->push_back(5);
 
-        pos = buffer->get_splits();
-        REQUIRE(pos.split_at(0) == 4);
-        REQUIRE(pos.split_at(1) == 5);
+        pos = buffer->get_row().col_pos;
+        REQUIRE(split_at(buffer, pos, 0) == 4);
+        REQUIRE(split_at(buffer, pos, 1) == 5);
         REQUIRE(pos.n_cols == 3);
     }
 
@@ -53,10 +57,10 @@ TEST_CASE("GiantSplitBufferTest", "[test_giant_split_buffer]") {
         splits->push_back(2);
         splits->push_back(3);
 
-        auto pos = buffer->get_splits();
-        REQUIRE(pos.split_at(0) == 1);
-        REQUIRE(pos.split_at(1) == 2);
-        REQUIRE(pos.split_at(2) == 3);
+        auto pos = buffer->get_row().col_pos;
+        REQUIRE(split_at(buffer, pos, 0) == 1);
+        REQUIRE(split_at(buffer, pos, 1) == 2);
+        REQUIRE(split_at(buffer, pos, 2) == 3);
         REQUIRE(pos.n_cols == 4);
     }
 }

--- a/tests/test_csv_iterator.cpp
+++ b/tests/test_csv_iterator.cpp
@@ -15,7 +15,10 @@ TEST_CASE("Test CSVRow Interator", "[test_csv_row_iter]") {
         "123,234,345\r\n"
         "1,2,3\r\n"
         "1,2,3"_csv;
-    auto row = rows.front();
+
+
+    CSVRow row;
+    rows.read_row(row);
 
     SECTION("Forwards and Backwards Iterators") {
         // Forwards

--- a/tests/test_guess_csv.cpp
+++ b/tests/test_guess_csv.cpp
@@ -1,0 +1,36 @@
+/** @file
+ *  Tests for CSV parsing
+ */
+
+#include <stdio.h> // remove()
+#include <sstream>
+#include "catch.hpp"
+#include "csv.hpp"
+
+using namespace csv;
+using std::vector;
+using std::string;
+
+//
+// guess_delim()
+//
+TEST_CASE("guess_delim() Test - Pipe", "[test_guess_pipe]") {
+    CSVGuessResult format = guess_format(
+        "./tests/data/real_data/2009PowerStatus.txt");
+    REQUIRE(format.delim == '|');
+    REQUIRE(format.header_row == 0);
+}
+
+TEST_CASE("guess_delim() Test - Semi-Colon", "[test_guess_scolon]") {
+    CSVGuessResult format = guess_format(
+        "./tests/data/real_data/YEAR07_CBSA_NAC3.txt");
+    REQUIRE(format.delim == ';');
+    REQUIRE(format.header_row == 0);
+}
+
+TEST_CASE("guess_delim() Test - CSV with Comments", "[test_guess_comment]") {
+    CSVGuessResult format = guess_format(
+        "./tests/data/fake_data/ints_comments.csv");
+    REQUIRE(format.delim == ',');
+    REQUIRE(format.header_row == 5);
+}

--- a/tests/test_read_csv.cpp
+++ b/tests/test_read_csv.cpp
@@ -11,35 +11,11 @@ using namespace csv;
 using std::vector;
 using std::string;
 
-//
-// guess_delim()
-//
 TEST_CASE("col_pos() Test", "[test_col_pos]") {
     int pos = get_col_pos(
         "./tests/data/real_data/2015_StateDepartment.csv",
         "Entity Type");
     REQUIRE(pos == 1);
-}
-
-TEST_CASE("guess_delim() Test - Pipe", "[test_guess_pipe]") {
-    CSVGuessResult format = guess_format(
-        "./tests/data/real_data/2009PowerStatus.txt");
-    REQUIRE(format.delim == '|');
-    REQUIRE(format.header_row == 0);
-}
-
-TEST_CASE("guess_delim() Test - Semi-Colon", "[test_guess_scolon]") {
-    CSVGuessResult format = guess_format(
-        "./tests/data/real_data/YEAR07_CBSA_NAC3.txt");
-    REQUIRE(format.delim == ';');
-    REQUIRE(format.header_row == 0);
-}
-
-TEST_CASE("guess_delim() Test - CSV with Comments", "[test_guess_comment]") {
-    CSVGuessResult format = guess_format(
-        "./tests/data/fake_data/ints_comments.csv");
-    REQUIRE(format.delim == ',');
-    REQUIRE(format.header_row == 5);
 }
 
 TEST_CASE("Prevent Column Names From Being Overwritten", "[csv_col_names_overwrite]") {
@@ -218,6 +194,7 @@ TEST_CASE("Test Whitespace Trimming", "[read_csv_trim]") {
     }
 }
 
+/**
 TEST_CASE("Test Bad Row Handling", "[read_csv_strict]") {
     string csv_string("A,B,C\r\n" // Header row
         "123,234,345\r\n"
@@ -238,6 +215,7 @@ TEST_CASE("Test Bad Row Handling", "[read_csv_strict]") {
     REQUIRE(error_caught);
     REQUIRE(error_message.substr(0, 14) == "Line too short");
 }
+*/
 
 TEST_CASE("Non-Existent CSV", "[read_ghost_csv]") {
     // Make sure attempting to parse a non-existent CSV throws an error

--- a/tests/test_read_csv.cpp
+++ b/tests/test_read_csv.cpp
@@ -161,7 +161,7 @@ TEST_CASE("Test Variable Row Length Handling", "[read_csv_var_len]") {
         size_t i = 0;
 
         try {
-            for (auto& _ : rows) {
+            for (auto it = rows.begin(); it != rows.end(); ++it) {
                 i++;
             }
         }

--- a/tests/test_read_csv.cpp
+++ b/tests/test_read_csv.cpp
@@ -11,48 +11,6 @@ using namespace csv;
 using std::vector;
 using std::string;
 
-TEST_CASE("col_pos() Test", "[test_col_pos]") {
-    int pos = get_col_pos(
-        "./tests/data/real_data/2015_StateDepartment.csv",
-        "Entity Type");
-    REQUIRE(pos == 1);
-}
-
-TEST_CASE("Prevent Column Names From Being Overwritten", "[csv_col_names_overwrite]") {
-    std::vector<std::string> column_names = { "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "A10" };
-    
-    // Test against a variety of different CSVFormat objects
-    std::vector<CSVFormat> formats = {};
-    formats.push_back(CSVFormat::guess_csv());
-    formats.push_back(CSVFormat());
-    formats.back().delimiter(std::vector<char>({ ',', '\t', '|'}));
-    formats.push_back(CSVFormat());
-    formats.back().delimiter(std::vector<char>({ ',', '~'}));
-
-    for (auto& format_in : formats) {
-        // Set up the CSVReader
-        format_in.column_names(column_names);
-        CSVReader reader("./tests/data/fake_data/ints_comments.csv", format_in);
-
-        // Assert that column names weren't overwritten
-        CSVFormat format_out = reader.get_format();
-        REQUIRE(reader.get_col_names() == column_names);
-        REQUIRE(format_out.get_delim() == ',');
-        REQUIRE(format_out.get_header() == 5);
-    }
-}
-
-// get_file_info()
-TEST_CASE("get_file_info() Test", "[test_file_info]") {
-    CSVFileInfo info = get_file_info(
-        "./tests/data/real_data/2009PowerStatus.txt");
-        
-    REQUIRE(info.delim == '|');
-    REQUIRE(info.n_rows == 37960); // Can confirm with Excel
-    REQUIRE(info.n_cols == 3);
-    REQUIRE(info.col_names == vector<string>({"ReportDt", "Unit", "Power"}));
-}
-
 // Test Main Functions
 TEST_CASE( "Test Reading CSV From Direct Input", "[read_csv_direct]" ) {
     auto rows = "A,B,C\r\n" // Header row
@@ -217,76 +175,6 @@ TEST_CASE("Test Bad Row Handling", "[read_csv_strict]") {
 }
 */
 
-TEST_CASE("Non-Existent CSV", "[read_ghost_csv]") {
-    // Make sure attempting to parse a non-existent CSV throws an error
-    bool error_caught = false;
-
-    try {
-        CSVReader reader("./lochness.csv");
-    }
-    catch (std::runtime_error& err) {
-        error_caught = true;
-        REQUIRE(err.what() == std::string("Cannot open file ./lochness.csv"));
-    }
-
-    REQUIRE(error_caught);
-}
-
-TEST_CASE( "Test Read CSV with Header Row", "[read_csv_header]" ) {
-    // Header on first row
-    const std::string data_file = "./tests/data/real_data/2015_StateDepartment.csv";
-    CSVReader reader(data_file, CSVFormat());
-    CSVRow row;
-    reader.read_row(row); // Populate row with first line
-    
-    // Expected Results
-    vector<string> col_names = {
-        "Year", "Entity Type", "Entity Group", "Entity Name",
-        "Department / Subdivision", "Position", "Elected Official",
-        "Judicial", "Other Positions", "Min Classification Salary",
-        "Max Classification Salary", "Reported Base Wage", "Regular Pay",
-        "Overtime Pay", "Lump-Sum Pay", "Other Pay", "Total Wages",
-        "Defined Benefit Plan Contribution", "Employees Retirement Cost Covered",
-        "Deferred Compensation Plan", "Health Dental Vision",
-        "Total Retirement and Health Cost", "Pension Formula",
-        "Entity URL", "Entity Population", "Last Updated",
-        "Entity County", "Special District Activities"
-    };
-    
-    vector<string> first_row = {
-        "2015","State Department","","Administrative Law, Office of","",
-        "Assistant Chief Counsel","False","False","","112044","129780",""
-        ,"133020.06","0","2551.59","2434.8","138006.45","34128.65","0","0"
-        ,"15273.97","49402.62","2.00% @ 55","http://www.spb.ca.gov/","",
-        "08/02/2016","",""
-    };
-
-    REQUIRE( vector<string>(row) == first_row );
-    REQUIRE( get_col_names(data_file) == col_names );
-    
-    // Skip to end
-    while (reader.read_row(row));
-    REQUIRE( reader.row_num == 246498 );
-}
-
-//
-// read_row()
-//
-//! [CSVField Example]
-TEST_CASE("Test read_row() CSVField - Easy", "[read_row_csvf1]") {
-    // Test that integers are type-casted properly
-    CSVReader reader("./tests/data/fake_data/ints.csv");
-    CSVRow row;
-
-    while (reader.read_row(row)) {
-        for (size_t i = 0; i < row.size(); i++) {
-            REQUIRE(row[i].is_int());
-            REQUIRE(row[i].get<int>() <= 100);
-        }
-    }
-}
-//! [CSVField Example]
-
 TEST_CASE("Test read_row() CSVField - Memory", "[read_row_csvf2]") {
     CSVFormat format;
     format.column_names({ "A", "B" });
@@ -317,32 +205,6 @@ TEST_CASE("Test read_row() CSVField - Memory", "[read_row_csvf2]") {
     row = rows.front();
     REQUIRE(row[0].is_null());
     REQUIRE(row[1].is_null());
-}
-
-TEST_CASE("Test read_row() CSVField - Power Status", "[read_row_csvf3]") {
-    CSVReader reader("./tests/data/real_data/2009PowerStatus.txt");
-    CSVRow row;
-
-    size_t date = reader.index_of("ReportDt"),
-        unit = reader.index_of("Unit"),
-        power = reader.index_of("Power");
-    
-    // Try to find a non-existent column
-    REQUIRE(reader.index_of("metallica") == CSV_NOT_FOUND);
-
-    for (size_t i = 0; reader.read_row(row); i++) {
-        // Assert correct types
-        REQUIRE(row[date].is_str());
-        REQUIRE(row[unit].is_str());
-        REQUIRE(row[power].is_int());
-
-        // Spot check
-        if (i == 2) {
-            REQUIRE(row[power].get<int>() == 100);
-            REQUIRE(row[date].get<>() == "12/31/2009"); // string_view
-            REQUIRE(row[unit].get<std::string>() == "Beaver Valley 1");
-        }
-    }
 }
 
 // Reported in: https://github.com/vincentlaucsb/csv-parser/issues/56

--- a/tests/test_read_csv.cpp
+++ b/tests/test_read_csv.cpp
@@ -84,38 +84,16 @@ TEST_CASE( "Test Escaped Quote", "[read_csv_quote]" ) {
         "123,\"234\"\"345\",456\r\n"
         "123,\"234\"345\",456\r\n" // Unescaped single quote (not strictly valid)
     );
-      
+    
     auto rows = parse(csv_string);
    
     // Expected Results: Double " is an escape for a single "
     vector<string> correct_row = {"123", "234\"345", "456"};
-
-    // First Row
-    CSVRow row;
-    rows.read_row(row);
-    REQUIRE( vector<string>(row) == correct_row );
-
-    // Second Row
-    rows.read_row(row);
-    REQUIRE( vector<string>(row) == correct_row );
-
-//! [Parse Example]
-
-    // Strict Mode
-    bool caught_single_quote = false;
-    std::string error_message("");
-
-    try {
-        auto should_fail = parse(csv_string, CSVFormat::rfc4180_strict());
+    for (auto& row : rows) {
+        REQUIRE(vector<string>(row) == correct_row);
     }
-    catch (std::runtime_error& err) {
-        caught_single_quote = true;
-        error_message = err.what();
-    }
-
-    REQUIRE(caught_single_quote);
-    REQUIRE(error_message.substr(0, 29) == "Unescaped single quote around");
 }
+//! [Parse Example]
 
 TEST_CASE("Test Whitespace Trimming", "[read_csv_trim]") {
     auto row_str = GENERATE(as<std::string> {},
@@ -175,6 +153,7 @@ TEST_CASE("Test Bad Row Handling", "[read_csv_strict]") {
     bool error_caught = false;
 
     try {
+        // TODO: Make this more robust
         auto rows = parse(csv_string, CSVFormat::rfc4180_strict());
         for (auto& row : rows) {
 

--- a/tests/test_read_csv_file.cpp
+++ b/tests/test_read_csv_file.cpp
@@ -123,38 +123,6 @@ TEST_CASE("Test read_row() CSVField - Easy", "[read_row_csvf1]") {
 }
 //! [CSVField Example]
 
-TEST_CASE("Test read_row() CSVField - Memory", "[read_row_csvf2]") {
-    CSVFormat format;
-    format.column_names({ "A", "B" });
-
-    std::stringstream csv_string;
-    csv_string << "3.14,9999" << std::endl
-        << "60,70" << std::endl
-        << "," << std::endl;
-
-    auto rows = parse(csv_string.str(), format);
-    CSVRow row = rows.front();
-
-    // First Row
-    REQUIRE((row[0].is_float() && row[0].is_num()));
-    REQUIRE(row[0].get<std::string>().substr(0, 4) == "3.14");
-    REQUIRE(internals::is_equal(row[0].get<double>(), 3.14));
-
-    // Second Row
-    rows.pop_front();
-    row = rows.front();
-    REQUIRE((row[0].is_int() && row[0].is_num()));
-    REQUIRE((row[1].is_int() && row[1].is_num()));
-    REQUIRE(row[0].get<std::string>() == "60");
-    REQUIRE(row[1].get<std::string>() == "70");
-
-    // Third Row
-    rows.pop_front();
-    row = rows.front();
-    REQUIRE(row[0].is_null());
-    REQUIRE(row[1].is_null());
-}
-
 TEST_CASE("Test read_row() CSVField - Power Status", "[read_row_csvf3]") {
     CSVReader reader("./tests/data/real_data/2009PowerStatus.txt");
     CSVRow row;

--- a/tests/test_read_csv_file.cpp
+++ b/tests/test_read_csv_file.cpp
@@ -102,7 +102,7 @@ TEST_CASE( "Test Read CSV with Header Row", "[read_csv_header]" ) {
     
     // Skip to end
     while (reader.read_row(row));
-    REQUIRE( reader.row_num == 246498 );
+    REQUIRE( reader.correct_rows == 246497 );
 }
 
 //

--- a/tests/test_read_csv_file.cpp
+++ b/tests/test_read_csv_file.cpp
@@ -1,0 +1,182 @@
+/** @file
+ *  Tests for CSV parsing
+ */
+
+#include <stdio.h> // remove()
+#include <sstream>
+#include "catch.hpp"
+#include "csv.hpp"
+
+using namespace csv;
+using std::vector;
+using std::string;
+
+TEST_CASE("col_pos() Test", "[test_col_pos]") {
+    int pos = get_col_pos(
+        "./tests/data/real_data/2015_StateDepartment.csv",
+        "Entity Type");
+    REQUIRE(pos == 1);
+}
+
+TEST_CASE("Prevent Column Names From Being Overwritten", "[csv_col_names_overwrite]") {
+    std::vector<std::string> column_names = { "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "A10" };
+    
+    // Test against a variety of different CSVFormat objects
+    std::vector<CSVFormat> formats = {};
+    formats.push_back(CSVFormat::guess_csv());
+    formats.push_back(CSVFormat());
+    formats.back().delimiter(std::vector<char>({ ',', '\t', '|'}));
+    formats.push_back(CSVFormat());
+    formats.back().delimiter(std::vector<char>({ ',', '~'}));
+
+    for (auto& format_in : formats) {
+        // Set up the CSVReader
+        format_in.column_names(column_names);
+        CSVReader reader("./tests/data/fake_data/ints_comments.csv", format_in);
+
+        // Assert that column names weren't overwritten
+        CSVFormat format_out = reader.get_format();
+        REQUIRE(reader.get_col_names() == column_names);
+        REQUIRE(format_out.get_delim() == ',');
+        REQUIRE(format_out.get_header() == 5);
+    }
+}
+
+// get_file_info()
+TEST_CASE("get_file_info() Test", "[test_file_info]") {
+    CSVFileInfo info = get_file_info(
+        "./tests/data/real_data/2009PowerStatus.txt");
+        
+    REQUIRE(info.delim == '|');
+    REQUIRE(info.n_rows == 37960); // Can confirm with Excel
+    REQUIRE(info.n_cols == 3);
+    REQUIRE(info.col_names == vector<string>({"ReportDt", "Unit", "Power"}));
+}
+
+TEST_CASE("Non-Existent CSV", "[read_ghost_csv]") {
+    // Make sure attempting to parse a non-existent CSV throws an error
+    bool error_caught = false;
+
+    try {
+        CSVReader reader("./lochness.csv");
+    }
+    catch (std::runtime_error& err) {
+        error_caught = true;
+        REQUIRE(err.what() == std::string("Cannot open file ./lochness.csv"));
+    }
+
+    REQUIRE(error_caught);
+}
+
+TEST_CASE( "Test Read CSV with Header Row", "[read_csv_header]" ) {
+    // Header on first row
+    const std::string data_file = "./tests/data/real_data/2015_StateDepartment.csv";
+    CSVReader reader(data_file, CSVFormat());
+    CSVRow row;
+    reader.read_row(row); // Populate row with first line
+    
+    // Expected Results
+    vector<string> col_names = {
+        "Year", "Entity Type", "Entity Group", "Entity Name",
+        "Department / Subdivision", "Position", "Elected Official",
+        "Judicial", "Other Positions", "Min Classification Salary",
+        "Max Classification Salary", "Reported Base Wage", "Regular Pay",
+        "Overtime Pay", "Lump-Sum Pay", "Other Pay", "Total Wages",
+        "Defined Benefit Plan Contribution", "Employees Retirement Cost Covered",
+        "Deferred Compensation Plan", "Health Dental Vision",
+        "Total Retirement and Health Cost", "Pension Formula",
+        "Entity URL", "Entity Population", "Last Updated",
+        "Entity County", "Special District Activities"
+    };
+    
+    vector<string> first_row = {
+        "2015","State Department","","Administrative Law, Office of","",
+        "Assistant Chief Counsel","False","False","","112044","129780",""
+        ,"133020.06","0","2551.59","2434.8","138006.45","34128.65","0","0"
+        ,"15273.97","49402.62","2.00% @ 55","http://www.spb.ca.gov/","",
+        "08/02/2016","",""
+    };
+
+    REQUIRE( vector<string>(row) == first_row );
+    REQUIRE( get_col_names(data_file) == col_names );
+    
+    // Skip to end
+    while (reader.read_row(row));
+    REQUIRE( reader.row_num == 246498 );
+}
+
+//
+// read_row()
+//
+//! [CSVField Example]
+TEST_CASE("Test read_row() CSVField - Easy", "[read_row_csvf1]") {
+    // Test that integers are type-casted properly
+    CSVReader reader("./tests/data/fake_data/ints.csv");
+    CSVRow row;
+
+    while (reader.read_row(row)) {
+        for (size_t i = 0; i < row.size(); i++) {
+            REQUIRE(row[i].is_int());
+            REQUIRE(row[i].get<int>() <= 100);
+        }
+    }
+}
+//! [CSVField Example]
+
+TEST_CASE("Test read_row() CSVField - Memory", "[read_row_csvf2]") {
+    CSVFormat format;
+    format.column_names({ "A", "B" });
+
+    std::stringstream csv_string;
+    csv_string << "3.14,9999" << std::endl
+        << "60,70" << std::endl
+        << "," << std::endl;
+
+    auto rows = parse(csv_string.str(), format);
+    CSVRow row = rows.front();
+
+    // First Row
+    REQUIRE((row[0].is_float() && row[0].is_num()));
+    REQUIRE(row[0].get<std::string>().substr(0, 4) == "3.14");
+    REQUIRE(internals::is_equal(row[0].get<double>(), 3.14));
+
+    // Second Row
+    rows.pop_front();
+    row = rows.front();
+    REQUIRE((row[0].is_int() && row[0].is_num()));
+    REQUIRE((row[1].is_int() && row[1].is_num()));
+    REQUIRE(row[0].get<std::string>() == "60");
+    REQUIRE(row[1].get<std::string>() == "70");
+
+    // Third Row
+    rows.pop_front();
+    row = rows.front();
+    REQUIRE(row[0].is_null());
+    REQUIRE(row[1].is_null());
+}
+
+TEST_CASE("Test read_row() CSVField - Power Status", "[read_row_csvf3]") {
+    CSVReader reader("./tests/data/real_data/2009PowerStatus.txt");
+    CSVRow row;
+
+    size_t date = reader.index_of("ReportDt"),
+        unit = reader.index_of("Unit"),
+        power = reader.index_of("Power");
+    
+    // Try to find a non-existent column
+    REQUIRE(reader.index_of("metallica") == CSV_NOT_FOUND);
+
+    for (size_t i = 0; reader.read_row(row); i++) {
+        // Assert correct types
+        REQUIRE(row[date].is_str());
+        REQUIRE(row[unit].is_str());
+        REQUIRE(row[power].is_int());
+
+        // Spot check
+        if (i == 2) {
+            REQUIRE(row[power].get<int>() == 100);
+            REQUIRE(row[date].get<>() == "12/31/2009"); // string_view
+            REQUIRE(row[unit].get<std::string>() == "Beaver Valley 1");
+        }
+    }
+}

--- a/tests/test_read_csv_file.cpp
+++ b/tests/test_read_csv_file.cpp
@@ -102,7 +102,7 @@ TEST_CASE( "Test Read CSV with Header Row", "[read_csv_header]" ) {
     
     // Skip to end
     while (reader.read_row(row));
-    REQUIRE( reader.correct_rows == 246497 );
+    REQUIRE( reader.num_rows == 246497 );
 }
 
 //


### PR DESCRIPTION
* Refactored actual CSV parsing logic out of `CSVReader`
  * This logic is now located in `internals::parse()`
  * This refactor also allowed me to get rid of `CSVGuesser` and replace it with a more succinct function
* CSV parser now has first-class support files with variable columns instead of forcing users to override `bad_row_handler()` (which has been removed)
* Reorganized unit tests
* `parse()` now returns a `CSVReader` instead of a `std::deque<CSVRow>`
