### PR TITLE
Fix name collision with PAGE_SIZE macro.

### DIFF
--- a/include/internal/constants.hpp
+++ b/include/internal/constants.hpp
@@ -17,6 +17,11 @@
 
 namespace csv {
     namespace internals {
+        // PAGE_SIZE macro could be already defined by the host system.
+        #if defined(PAGE_SIZE)
+        #undef PAGE_SIZE
+        #endif
+
         // Get operating system specific details
         #if defined(_WIN32)
             inline int getpagesize() {


### PR DESCRIPTION
As mentioned in [here](http://lists.busybox.net/pipermail/buildroot/2019-March/244965.html) and  [here](https://github.com/jvm-profiling-tools/async-profiler/pull/85), `PAGE_SIZE` can be collided with the same name preprocessor macro that is defined in [<limits.h>](https://pubs.opengroup.org/onlinepubs/009695399/basedefs/limits.h.html), and cause `error: expected unqualified-id before numeric constant.` on compilation.

Also, an alternative to this solution could be to rename the local constant definition.