### PR TITLE
Put #pragma region behind an check for MSVC

### DIFF
--- a/include/internal/csv_row.cpp
+++ b/include/internal/csv_row.cpp
@@ -86,7 +86,9 @@ namespace csv {
         return ret;
     }
 
+#ifdef _MSC_VER
 #pragma region CSVRow Iterator
+#endif
     /** Return an iterator pointing to the first field. */
     CSV_INLINE CSVRow::iterator CSVRow::begin() const {
         return CSVRow::iterator(this, 0);
@@ -179,5 +181,7 @@ namespace csv {
         // Allows for iterator arithmetic
         return CSVRow::iterator::operator+(-n);
     }
+#ifdef _MSC_VER
 #pragma endregion CSVRow Iterator
+#endif
 }

--- a/include/internal/csv_row.hpp
+++ b/include/internal/csv_row.hpp
@@ -290,7 +290,9 @@ namespace csv {
         internals::RowData data;               /**< Contains row string and column positions. */
     };
 
+#ifdef _MSC_VER
 #pragma region CSVField::get Specializations
+#endif
     /** Retrieve this field's original string */
     template<>
     inline std::string CSVField::get<std::string>() {
@@ -315,7 +317,9 @@ namespace csv {
 
         return this->value;
     }
+#ifdef _MSC_VER
 #pragma endregion CSVField::get Specializations
+#endif
 
     /** Compares the contents of this field to a string */
     template<>


### PR DESCRIPTION
While the CMake file will pass a flag to GCC/clang to ignore unknown pragmas, this isn't practical when using the single-include variant of the parser, since it would require ignoring unknown pragmas for the whole compilation unit.

Here, I just added a check to see if the compiler was MSVC before each pragma region. I then regenerated the single-header version.

I'm not sure why the single-header version has such a large diff -- I think the order the files were concatenated by the Python script may have changed?

I also was only able to run the tests that didn't require the test data, as I couldn't immediately figure out how to acquire the data. The resulting single-file header does not produce any warnings with `g++ -Wall`, version 10.1.0.