### PR TITLE
fix: Updated math includes for GCC/G++ 9+

### DIFF
--- a/include/internal/csv_row.hpp
+++ b/include/internal/csv_row.hpp
@@ -3,7 +3,7 @@
  */
 
 #pragma once
-#include <math.h>
+#include <cmath>
 #include <vector>
 #include <string>
 #include <iterator>

--- a/include/internal/data_type.h
+++ b/include/internal/data_type.h
@@ -3,7 +3,7 @@
  */
 
 #pragma once
-#include <math.h>
+#include <cmath>
 #include <cctype>
 #include <string>
 #include <cassert>

--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -3250,7 +3250,7 @@ namespace csv {
  *  @brief Implements data type parsing functionality
  */
 
-#include <math.h>
+#include <cmath>
 #include <cctype>
 #include <string>
 #include <cassert>
@@ -3804,7 +3804,7 @@ namespace csv {
  *  Defines the data type used for storing information about a CSV row
  */
 
-#include <math.h>
+#include <cmath>
 #include <vector>
 #include <string>
 #include <iterator>

--- a/single_include_test/csv.hpp
+++ b/single_include_test/csv.hpp
@@ -3250,7 +3250,7 @@ namespace csv {
  *  @brief Implements data type parsing functionality
  */
 
-#include <math.h>
+#include <cmath>
 #include <cctype>
 #include <string>
 #include <cassert>
@@ -3804,7 +3804,7 @@ namespace csv {
  *  Defines the data type used for storing information about a CSV row
  */
 
-#include <math.h>
+#include <cmath>
 #include <vector>
 #include <string>
 #include <iterator>


### PR DESCRIPTION
Compiling the library with GCC/G++ 9 or later fails. This is because of issues with `math.h` polluting the global namespace. 
I've updated the math headers to use cmath, which should be fine. But perhaps run exhaustive test cases to be sure. 