### PR TITLE
Fix/math h to cmath

### DIFF
--- a/include/internal/csv_row.hpp
+++ b/include/internal/csv_row.hpp
@@ -3,7 +3,7 @@
  */
 
 #pragma once
-#include <math.h>
+#include <cmath>
 #include <vector>
 #include <string>
 #include <iterator>

--- a/include/internal/data_type.h
+++ b/include/internal/data_type.h
@@ -3,7 +3,7 @@
  */
 
 #pragma once
-#include <math.h>
+#include <cmath>
 #include <cctype>
 #include <string>
 #include <cassert>

--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -5955,8 +5955,8 @@ namespace csv {
             counts.push_back({});
             rolling_means.push_back(0);
             rolling_vars.push_back(0);
-            mins.push_back(NAN);
-            maxes.push_back(NAN);
+            mins.push_back(std::nanl(""));
+            maxes.push_back(std::nanl(""));
             n.push_back(0);
         }
 
@@ -6047,9 +6047,9 @@ namespace csv {
          *  @param[in]  x_n Data observation
          *  @param[out] i   The column index that should be updated
          */
-        if (isnan(this->mins[i]))
+        if (std::isnan(this->mins[i]))
             this->mins[i] = x_n;
-        if (isnan(this->maxes[i]))
+        if (std::isnan(this->maxes[i]))
             this->maxes[i] = x_n;
         
         if (x_n < this->mins[i])

--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -3250,7 +3250,7 @@ namespace csv {
  *  @brief Implements data type parsing functionality
  */
 
-#include <math.h>
+#include <cmath>
 #include <cctype>
 #include <string>
 #include <cassert>
@@ -3804,7 +3804,7 @@ namespace csv {
  *  Defines the data type used for storing information about a CSV row
  */
 
-#include <math.h>
+#include <cmath>
 #include <vector>
 #include <string>
 #include <iterator>

--- a/single_include_test/csv.hpp
+++ b/single_include_test/csv.hpp
@@ -3250,7 +3250,7 @@ namespace csv {
  *  @brief Implements data type parsing functionality
  */
 
-#include <math.h>
+#include <cmath>
 #include <cctype>
 #include <string>
 #include <cassert>
@@ -3804,7 +3804,7 @@ namespace csv {
  *  Defines the data type used for storing information about a CSV row
  */
 
-#include <math.h>
+#include <cmath>
 #include <vector>
 #include <string>
 #include <iterator>


### PR DESCRIPTION
Corrected the residual math.h function calls that had not been changed to their cmath equivalent. This was needed since the header only file was throwing compilation errors (issue #112).  

Changing isnan() to std::isnan() and changing NAN to std::nanl("") fixed the problem. 