### PR TITLE
fix: initialize _format in CSVReader constructor

### DIFF
--- a/include/internal/csv_reader.cpp
+++ b/include/internal/csv_reader.cpp
@@ -150,7 +150,7 @@ namespace csv {
      *  \snippet tests/test_read_csv.cpp CSVField Example
      *
      */
-    CSV_INLINE CSVReader::CSVReader(csv::string_view filename, CSVFormat format) {
+	CSV_INLINE CSVReader::CSVReader(csv::string_view filename, CSVFormat format) : _format(format) {
         auto head = internals::get_csv_head(filename);
         using Parser = internals::MmapParser;
 


### PR DESCRIPTION
I had trouble with the following code snippet:
```
csv::CSVFormat format;
format.delimiter(',').quote(false).no_header();
csv::CSVReader csv_reader(csv_file, format);
for (csv::CSVRow& row: csv_reader) { 
   // do sth with the rows 
}
```

**Bug:** First line is still parsed as headers not as a row like reported in #132 .

**Cause:** field `_format` was not initialized. That caused the function call in the following line to rely on the default constructed value of field `CSVFormat _format`:
https://github.com/vincentlaucsb/csv-parser/blob/621a9d94e4eab8acd31a8ac35577a68acdc1870f/include/internal/csv_reader.cpp#L169 

**Fix:** Initialize the field `_format` in the constructor CSVReader::CSVReader(csv::string_view filename, CSVFormat format). 
In the other constructors it is actually initialized. So it was probably simply looked over. 