### PR TITLE
Feature/buffered writer

### DIFF
--- a/include/internal/csv_reader.cpp
+++ b/include/internal/csv_reader.cpp
@@ -12,8 +12,9 @@ namespace csv {
             for (size_t i = 0; i < row.size(); i++) {
                 ret << row[i];
                 if (i + 1 < row.size()) ret << delim;
-                else ret << std::endl;
+                else ret << '\n';
             }
+            ret.flush();
 
             return ret.str();
         }

--- a/include/internal/csv_writer.hpp
+++ b/include/internal/csv_writer.hpp
@@ -79,6 +79,8 @@ namespace csv {
      *  @tparam OutputStream The output stream, e.g. `std::ofstream`, `std::stringstream`
      *  @tparam Delim        The delimiter character
      *  @tparam Quote        The quote character
+     *  @tparam Flush        True: flush after every writing function,
+     *                       false: you need to flush explicitly if needed.
      *
      *  @par Hint
      *  Use the aliases csv::CSVWriter<OutputStream> to write CSV
@@ -91,7 +93,7 @@ namespace csv {
      *  @par Example w/ std::tuple
      *  @snippet test_write_csv.cpp CSV Writer Tuple Example
      */
-    template<class OutputStream, char Delim, char Quote>
+    template<class OutputStream, char Delim, char Quote, bool Flush>
     class DelimWriter {
     public:
         /** Construct a DelimWriter over the specified output stream
@@ -108,6 +110,13 @@ namespace csv {
          */
         DelimWriter(const std::string& filename) : DelimWriter(std::ifstream(filename)) {};
 
+        /** Destructor will flush remaining data
+         *
+         */
+        ~DelimWriter() {
+            out.flush();
+        }
+
         /** Format a sequence of strings and write to CSV according to RFC 4180
          *
          *  @warning This does not check to make sure row lengths are consistent
@@ -123,7 +132,7 @@ namespace csv {
                 if (i + 1 != Size) out << Delim;
             }
 
-            out << std::endl;
+            end_out();
             return *this;
         }
 
@@ -154,8 +163,15 @@ namespace csv {
                 i++;
             }
 
-            out << std::endl;
+            end_out();
             return *this;
+        }
+
+        /** Flushes the written data
+         *
+         */
+        void flush() {
+            out.flush();
         }
 
     private:
@@ -237,7 +253,13 @@ namespace csv {
         template<size_t Index = 0, typename... T>
         typename std::enable_if<Index == sizeof...(T), void>::type write_tuple(const std::tuple<T...>& record) {
             (void)record;
-            out << std::endl;
+            end_out();
+        }
+
+        /** Ends a line in 'out' and flushes, if Flush is true.*/
+        void end_out() {
+            out << '\n';
+            IF_CONSTEXPR(Flush) out.flush();
         }
 
         OutputStream & out;
@@ -251,19 +273,19 @@ namespace csv {
      *  @note Use `csv::make_csv_writer()` to in instatiate this class over
      *        an actual output stream.
      */
-    template<class OutputStream>
-    using CSVWriter = DelimWriter<OutputStream, ',', '"'>;
+    template<class OutputStream, bool Flush=true>
+    using CSVWriter = DelimWriter<OutputStream, ',', '"', Flush>;
 
     /** Class for writing tab-separated values files
-*
+    *
      *  @sa csv::DelimWriter::write_row()
      *  @sa csv::DelimWriter::operator<<()
      *
      *  @note Use `csv::make_tsv_writer()` to in instatiate this class over
      *        an actual output stream.
      */
-    template<class OutputStream>
-    using TSVWriter = DelimWriter<OutputStream, '\t', '"'>;
+    template<class OutputStream, bool Flush=true>
+    using TSVWriter = DelimWriter<OutputStream, '\t', '"', Flush>;
 
     /** Return a csv::CSVWriter over the output stream */
     template<class OutputStream>
@@ -271,10 +293,22 @@ namespace csv {
         return CSVWriter<OutputStream>(out, quote_minimal);
     }
 
+    /** Return a buffered csv::CSVWriter over the output stream (does not auto flush) */
+    template<class OutputStream>
+    inline CSVWriter<OutputStream, false> make_csv_writer_buffered(OutputStream& out, bool quote_minimal=true) {
+        return CSVWriter<OutputStream, false>(out, quote_minimal);
+    }
+
     /** Return a csv::TSVWriter over the output stream */
     template<class OutputStream>
     inline TSVWriter<OutputStream> make_tsv_writer(OutputStream& out, bool quote_minimal=true) {
         return TSVWriter<OutputStream>(out, quote_minimal);
+    }
+
+    /** Return a buffered csv::TSVWriter over the output stream (does not auto flush) */
+    template<class OutputStream>
+    inline TSVWriter<OutputStream, false> make_tsv_writer_buffered(OutputStream& out, bool quote_minimal=true) {
+        return TSVWriter<OutputStream, false>(out, quote_minimal);
     }
     ///@}
 }

--- a/include/internal/csv_writer.hpp
+++ b/include/internal/csv_writer.hpp
@@ -81,6 +81,7 @@ namespace csv {
      *  @tparam Quote        The quote character
      *  @tparam Flush        True: flush after every writing function,
      *                       false: you need to flush explicitly if needed.
+     *                       In both cases the destructor will flush.
      *
      *  @par Hint
      *  Use the aliases csv::CSVWriter<OutputStream> to write CSV
@@ -273,7 +274,7 @@ namespace csv {
      *  @note Use `csv::make_csv_writer()` to in instatiate this class over
      *        an actual output stream.
      */
-    template<class OutputStream, bool Flush=true>
+    template<class OutputStream, bool Flush = true>
     using CSVWriter = DelimWriter<OutputStream, ',', '"', Flush>;
 
     /** Class for writing tab-separated values files
@@ -284,7 +285,7 @@ namespace csv {
      *  @note Use `csv::make_tsv_writer()` to in instatiate this class over
      *        an actual output stream.
      */
-    template<class OutputStream, bool Flush=true>
+    template<class OutputStream, bool Flush = true>
     using TSVWriter = DelimWriter<OutputStream, '\t', '"', Flush>;
 
     /** Return a csv::CSVWriter over the output stream */

--- a/tests/test_round_trip.cpp
+++ b/tests/test_round_trip.cpp
@@ -14,25 +14,25 @@ TEST_CASE("Simple Buffered Integer Round Trip Test", "[test_roundtrip_int]") {
     std::ofstream outfile(filename, std::ios::binary);
     auto writer = make_csv_writer_buffered(outfile);
 
-    writer << std::vector<std::string>({ "A", "B", "C", "D", "E" });
+    writer << std::vector<std::string>({"A", "B", "C", "D", "E"});
 
     const size_t n_rows = 1000000;
 
     for (size_t i = 0; i <= n_rows; i++) {
-    auto str = internals::to_string(i);
-    writer << std::array<csv::string_view, 5>({ str, str, str, str, str });
+        auto str = internals::to_string(i);
+        writer << std::array<csv::string_view, 5>({str, str, str, str, str});
     }
     writer.flush();
 
     CSVReader reader(filename);
 
     size_t i = 0;
-    for (auto& row : reader) {
-    for (auto& col : row) {
-    REQUIRE(col == i);
-    }
+    for (auto &row : reader) {
+        for (auto &col : row) {
+            REQUIRE(col == i);
+        }
 
-    i++;
+        i++;
     }
 
     REQUIRE(reader.n_rows() == n_rows);

--- a/tests/test_round_trip.cpp
+++ b/tests/test_round_trip.cpp
@@ -9,6 +9,37 @@
 
 using namespace csv;
 
+TEST_CASE("Simple Buffered Integer Round Trip Test", "[test_roundtrip_int]") {
+    auto filename = "round_trip.csv";
+    std::ofstream outfile(filename, std::ios::binary);
+    auto writer = make_csv_writer_buffered(outfile);
+
+    writer << std::vector<std::string>({ "A", "B", "C", "D", "E" });
+
+    const size_t n_rows = 1000000;
+
+    for (size_t i = 0; i <= n_rows; i++) {
+    auto str = internals::to_string(i);
+    writer << std::array<csv::string_view, 5>({ str, str, str, str, str });
+    }
+    writer.flush();
+
+    CSVReader reader(filename);
+
+    size_t i = 0;
+    for (auto& row : reader) {
+    for (auto& col : row) {
+    REQUIRE(col == i);
+    }
+
+    i++;
+    }
+
+    REQUIRE(reader.n_rows() == n_rows);
+
+    remove(filename);
+}
+
 TEST_CASE("Simple Integer Round Trip Test", "[test_roundtrip_int]") {
     auto filename = "round_trip.csv";
     std::ofstream outfile(filename, std::ios::binary);


### PR DESCRIPTION
The performance of the `DelimWriter` class can be improved by flushing only if needed.
I added a template parameter to disable the flushing in the `operator<<`, a flush function and a destructor that performs a final flush on destruction. 
Because of the new parameter the aliases `CSVWriter` and `TSVWriter` had to be adapted. The default parameter are set in a way to keep their previous behaviour (flushing directly).
`make_csv_writer` and `make_tsv_writer` will still return the flushing version, however there are new helper functions `make_csv_writer_buffered` and `make_tsv_writer_buffered` for creating `DelimWriter` objects without the auto flush.
A new test was added for demonstration.
