### PR TITLE
CMake options to disable programs building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,10 @@ endif()
 add_subdirectory(${CSV_SOURCE_DIR})
 
 ## Executables
-add_subdirectory("programs")
+option(CSV_BUILD_PROGRAMS "Allow to disable building of programs" ON)
+if (CSV_BUILD_PROGRAMS)
+    add_subdirectory("programs")
+endif()
 
 ## Developer settings
 if (CSV_DEVELOPER)


### PR DESCRIPTION
When linked to my project multiple executable gets build that I don't need nor want.

With this options I can disable the building of programs if I want, default is set to build them.