### PR TITLE
W32 lean and mean

### DIFF
--- a/include/internal/common.hpp
+++ b/include/internal/common.hpp
@@ -10,8 +10,8 @@
 #include <deque>
 
 #if defined(_WIN32)
-# include <Windows.h>
 # define WIN32_LEAN_AND_MEAN
+# include <Windows.h>
 # undef max
 # undef min
 #elif defined(__linux__)

--- a/include/internal/common.hpp
+++ b/include/internal/common.hpp
@@ -10,7 +10,9 @@
 #include <deque>
 
 #if defined(_WIN32)
-# define WIN32_LEAN_AND_MEAN
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
 # include <Windows.h>
 # undef max
 # undef min

--- a/include/internal/common.hpp
+++ b/include/internal/common.hpp
@@ -10,12 +10,12 @@
 #include <deque>
 
 #if defined(_WIN32)
-#include <Windows.h>
-#define WIN32_LEAN_AND_MEAN
-#undef max
-#undef min
+# include <Windows.h>
+# define WIN32_LEAN_AND_MEAN
+# undef max
+# undef min
 #elif defined(__linux__)
-#include <unistd.h>
+# include <unistd.h>
 #endif
 
  /** Helper macro which should be #defined as "inline"

--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -1828,12 +1828,14 @@ using shared_ummap_sink = basic_shared_mmap_sink<unsigned char>;
 #include <deque>
 
 #if defined(_WIN32)
-#include <Windows.h>
-#define WIN32_LEAN_AND_MEAN
-#undef max
-#undef min
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# include <Windows.h>
+# undef max
+# undef min
 #elif defined(__linux__)
-#include <unistd.h>
+# include <unistd.h>
 #endif
 
  /** Helper macro which should be #defined as "inline"


### PR DESCRIPTION
Small but necessary changes to compile with Visual C++ at maximum warnings in circumstances where WIN32_LEAN_AND_MEAN is (already) defined in build settings