### PR TITLE
Fix for failing to parse leading and trailing escaped quotes

### DIFF
--- a/include/internal/basic_csv_parser.cpp
+++ b/include/internal/basic_csv_parser.cpp
@@ -182,6 +182,8 @@ namespace csv {
                     if (this->field_length == 0) {
                         quote_escape = true;
                         data_pos++;
+                        if (field_start == UNINITIALIZED_FIELD && !ws_flag(in[data_pos]))
+                            field_start = (int)(data_pos - current_row_start());
                         break;
                     }
 

--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -6959,6 +6959,8 @@ namespace csv {
                     if (this->field_length == 0) {
                         quote_escape = true;
                         data_pos++;
+                        if (field_start == UNINITIALIZED_FIELD && !ws_flag(in[data_pos]))
+                            field_start = (int)(data_pos - current_row_start());
                         break;
                     }
 

--- a/tests/test_read_csv.cpp
+++ b/tests/test_read_csv.cpp
@@ -127,6 +127,30 @@ TEST_CASE( "Test Escaped Quote", "[read_csv_quote]" ) {
 }
 //! [Parse Example]
 
+//! [Parse Example]
+TEST_CASE( "Test leading and trailing escaped quote", "[read_csv_quote]" ) {
+    // Per RFC 4180, escaped quotes should be doubled up
+    auto csv_string = GENERATE(as<std::string> {},
+        (
+            "A,B,C\r\n" // Header row
+            "123,345,\"\"\"234\"\"\""
+        )
+    );
+    
+    SECTION("Double escaped Quote") {
+        auto rows = parse(csv_string);
+
+        REQUIRE(rows.get_col_names() == vector<string>({ "A", "B", "C" }));
+
+        // Expected Results: Double quotes
+        vector<string> correct_row = { "123", "345", "\"234\"" };
+        for (auto& row : rows) {
+            REQUIRE(vector<string>(row) == correct_row);
+        }
+    }
+}
+//! [Parse Example]
+
 TEST_CASE("Test Whitespace Trimming", "[read_csv_trim]") {
     auto row_str = GENERATE(as<std::string> {},
         "A,B,C\r\n" // Header row

--- a/tests/test_write_csv.cpp
+++ b/tests/test_write_csv.cpp
@@ -24,6 +24,11 @@ TEST_CASE("Basic CSV Writing Cases", "[test_csv_write]") {
         correct << "\"\"\"What does it mean to be RFC 4180 compliant?\"\" she asked.\"";
     }
 
+    SECTION("Leading and Trailing Quote Escape") {
+        writer << std::array<std::string, 1>({ "\"\"" });
+        correct << "\"\"\"\"\"\"";
+    }
+
     SECTION("Quote Minimal") {
         writer << std::array<std::string, 1>({ "This should not be quoted" });
         correct << "This should not be quoted";


### PR DESCRIPTION
Asking the writer to write \"1234\" results in \"\"\"1234\"\"\" being written. The Parser was unable to parse that result.