### PR TITLE
wrap RowCollection into unique_ptr

### DIFF
--- a/include/internal/csv_reader.hpp
+++ b/include/internal/csv_reader.hpp
@@ -156,7 +156,7 @@ namespace csv {
         std::vector<std::string> get_col_names() const;
         int index_of(csv::string_view col_name) const;
         ///@}
-        
+
         /** @name CSV Metadata: Attributes */
         ///@{
         /** Whether or not the file or stream contains valid CSV rows,
@@ -199,7 +199,7 @@ namespace csv {
         std::unique_ptr<internals::IBasicCSVParser> parser = nullptr;
 
         /** Queue of parsed CSV rows */
-        RowCollection records = RowCollection(100);
+        std::unique_ptr<RowCollection> records{new RowCollection(100)};
 
         size_t n_cols = 0;  /**< The number of columns in this CSV */
         size_t _n_rows = 0; /**< How many rows (minus header) have been read so far */

--- a/include/internal/csv_reader_iterator.cpp
+++ b/include/internal/csv_reader_iterator.cpp
@@ -7,15 +7,15 @@
 namespace csv {
     /** Return an iterator to the first row in the reader */
     CSV_INLINE CSVReader::iterator CSVReader::begin() {
-        if (this->records.empty()) {
+        if (this->records->empty()) {
             this->read_csv_worker = std::thread(&CSVReader::read_csv, this, internals::ITERATION_CHUNK_SIZE);
             this->read_csv_worker.join();
 
             // Still empty => return end iterator
-            if (this->records.empty()) return this->end();
+            if (this->records->empty()) return this->end();
         }
 
-        CSVReader::iterator ret(this, std::move(this->records.pop_front()));
+        CSVReader::iterator ret(this, std::move(this->records->pop_front()));
         return ret;
     }
 


### PR DESCRIPTION
Currently, with clang 11 the following problem exists:

```
In file included from /home/paul/dev/github/artpaul/csv-parser/include/internal/csv_reader.cpp:5:
/home/paul/dev/github/artpaul/csv-parser/include/internal/csv_reader.hpp:136:20: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
        CSVReader& operator=(CSVReader&& other) = default;
                   ^
/home/paul/dev/github/artpaul/csv-parser/include/internal/csv_reader.hpp:202:23: note: move assignment operator of 'CSVReader' is implicitly deleted because field 'records' has a deleted move assignment operator
        RowCollection records = RowCollection(100);
                      ^
/home/paul/dev/github/artpaul/csv-parser/include/internal/basic_csv_parser.hpp:177:24: note: copy assignment operator of 'ThreadSafeDeque<csv::CSVRow>' is implicitly deleted because field '_lock' has a deleted copy assignment operator
            std::mutex _lock;
                       ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/std_mutex.h:95:12: note: 'operator=' has been explicitly marked deleted here
    mutex& operator=(const mutex&) = delete;
           ^
1 warning generated.
```

The std::unique_ptr has a trivial move semantic, so by replacing RowCollection with std::unique_ptr<RowCollection> we will avoid all this strange mess.