### PR TITLE
fix some warnings produced by clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,14 @@ if (CSV_DEVELOPER)
 	    target_link_options(csv PUBLIC /PROFILE)
     endif()
 
+    # More error messages.
+    if (UNIX)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+        -Wall -Werror -Wextra -Wshadow -Wsign-compare \
+        -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self \
+        -Wconversion -Wno-sign-conversion")
+    endif()
+
     # Generate a single header library
     if(CMAKE_VERSION VERSION_LESS "3.12" OR ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
       find_package(PythonInterp 3 QUIET)

--- a/include/internal/basic_csv_parser.hpp
+++ b/include/internal/basic_csv_parser.hpp
@@ -270,7 +270,7 @@ namespace csv {
             /** Whether or not an attempt to find Unicode BOM has been made */
             bool unicode_bom_scan = false;
             bool _utf8_bom = false;
-            
+
             /** Where complete rows should be pushed to */
             RowCollection* _records = nullptr;
 
@@ -281,7 +281,7 @@ namespace csv {
             size_t& current_row_start() {
                 return this->current_row.data_start;
             }
-    
+
             void parse_field() noexcept;
 
             /** Finish parsing the current field */
@@ -305,7 +305,7 @@ namespace csv {
             StreamParser(TStream& source,
                 const CSVFormat& format,
                 const ColNamesPtr& col_names = nullptr
-            ) : _source(std::move(source)), IBasicCSVParser(format, col_names) {};
+            ) : IBasicCSVParser(format, col_names), _source(std::move(source)) {};
 
             StreamParser(
                 TStream& source,

--- a/include/internal/csv_reader.cpp
+++ b/include/internal/csv_reader.cpp
@@ -105,7 +105,7 @@ namespace csv {
             for (char cand_delim : delims) {
                 auto result = calculate_score(head, format.delimiter(cand_delim));
 
-                if (result.score > max_score) {
+                if ((size_t)result.score > max_score) {
                     max_score = (size_t)result.score;
                     current_delim = cand_delim;
                     header = result.header;
@@ -298,7 +298,7 @@ namespace csv {
                 }
             }
             else {
-                row = std::move(this->records->pop_front());
+                row = this->records->pop_front();
                 this->_n_rows++;
                 return true;
             }

--- a/include/internal/csv_reader_iterator.cpp
+++ b/include/internal/csv_reader_iterator.cpp
@@ -15,7 +15,7 @@ namespace csv {
             if (this->records->empty()) return this->end();
         }
 
-        CSVReader::iterator ret(this, std::move(this->records->pop_front()));
+        CSVReader::iterator ret(this, this->records->pop_front());
         return ret;
     }
 

--- a/tests/test_csv_iterator.cpp
+++ b/tests/test_csv_iterator.cpp
@@ -82,7 +82,7 @@ TEST_CASE("Basic CSVReader Iterator Test", "[read_ints_iter]") {
     std::vector<std::string> col_names = {
         "A", "B", "C", "D", "E", "F", "G", "H", "I", "J"
     };
-    size_t i = 1;
+    int i = 1;
 
     SECTION("Basic Iterator") {
         for (auto it = reader.begin(); it != reader.end(); ++it) {
@@ -113,7 +113,7 @@ TEST_CASE("CSVReader Iterator + std::max_elem", "[iter_max_elem]") {
     // The second file is a database of California state employee salaries
     CSVReader r1("./tests/data/fake_data/ints.csv"),
         r2("./tests/data/real_data/2015_StateDepartment.csv");
-    
+
     // Find largest number
     auto int_finder = [](CSVRow& left, CSVRow& right) {
         return (left["A"].get<int>() < right["A"].get<int>());

--- a/tests/test_csv_stat.cpp
+++ b/tests/test_csv_stat.cpp
@@ -11,7 +11,7 @@ TEST_CASE("Calculating Statistics from Direct Input", "[read_csv_stat_direct]" )
         int_str = std::to_string(i);
         int_list << int_str << "," << int_str << "," << int_str << "\r\n";
     }
-    
+
     // Expected results
     CSVFormat format;
     format.column_names({ "A", "B", "C" });
@@ -25,12 +25,12 @@ TEST_CASE("Calculating Statistics from Direct Input", "[read_csv_stat_direct]" )
     REQUIRE( reader.get_mins() == mins );
     REQUIRE( reader.get_maxes() == maxes );
     REQUIRE( reader.get_mean() == means );
-    REQUIRE( ceil(reader.get_variance()[0]) == 842 );
-    
+    REQUIRE( ceill(reader.get_variance()[0]) == 842 );
+
     // Make sure all integers between 1 and 100 have a count of 1
     for (int i = 1; i < 101; i++)
         REQUIRE( reader.get_counts()[0][std::to_string(i)] == 1 );
-    
+
     // Confirm column at pos 0 has 100 integers (type 2)
     REQUIRE( reader.get_dtypes()[0][DataType::CSV_INT8] == 100 );
 }
@@ -54,14 +54,14 @@ TEST_CASE( "Statistics - Rows of Integers", "[read_csv_stat]" ) {
         REQUIRE(reader.get_mean() == means);
         REQUIRE(reader.get_mins()[0] == 1);
         REQUIRE(reader.get_maxes()[0] == 100);
-        REQUIRE(ceil(reader.get_variance()[0]) == 842);
+        REQUIRE(ceill(reader.get_variance()[0]) == 842);
     }
 }
 
 TEST_CASE( "Statistics - persons.csv", "[test_stat_person]" ) {
     CSVStat reader(PERSONS_CSV);
     REQUIRE(reader.get_maxes()[0] == 49999);
-    REQUIRE( ceil(reader.get_mean()[2]) == 42 );
+    REQUIRE( ceill(reader.get_mean()[2]) == 42 );
 }
 
 TEST_CASE("Data Types - persons.csv", "test_dtypes_person]") {

--- a/tests/test_raw_csv_data.cpp
+++ b/tests/test_raw_csv_data.cpp
@@ -6,7 +6,7 @@
 
 using namespace csv;
 using namespace csv::internals;
-using RowCollection = ThreadSafeDeque<CSVRow>;
+using RowCollectionTest = ThreadSafeDeque<CSVRow>;
 
 TEST_CASE("Basic CSV Parse Test", "[raw_csv_parse]") {
     std::stringstream csv("A,B,C\r\n"
@@ -14,7 +14,7 @@ TEST_CASE("Basic CSV Parse Test", "[raw_csv_parse]") {
         "1,2,3\r\n"
         "1,2,3");
 
-    RowCollection rows;
+    RowCollectionTest rows;
 
     StreamParser<std::stringstream> parser(
         csv,
@@ -61,7 +61,7 @@ TEST_CASE("Test Quote Escapes", "[test_parse_quote_escape]") {
         "1,\"23\"\"34\",5\r\n"      // Another escaped quote
         "1,\"\",2\r\n");           // Empty Field
 
-    RowCollection rows;
+    RowCollectionTest rows;
 
     StreamParser<std::stringstream> parser(
         csv,
@@ -178,7 +178,7 @@ TEST_CASE("Test Parser Whitespace Trimming", "[test_csv_trim]") {
     SECTION("Parse Test") {
         using namespace std;
 
-        RowCollection rows;
+        RowCollectionTest rows;
 
         auto csv = std::stringstream(row_str);
         StreamParser<std::stringstream> parser(
@@ -207,7 +207,7 @@ TEST_CASE("Test Parser Whitespace Trimming w/ Empty Fields", "[test_raw_ws_trim]
     auto csv_string = GENERATE(from_range(make_whitespace_test_cases()));
 
     SECTION("Parse Test") {
-        RowCollection rows;
+        RowCollectionTest rows;
 
         auto csv = std::stringstream(csv_string);
         StreamParser<std::stringstream> parser(


### PR DESCRIPTION
The warnings were:

```
csv-parser/include/internal/basic_csv_parser.hpp:308:17: error: field '_source' will be initialized after base 'csv::internals::IBasicCSVParser' [-Werror,-Wreorder-ctor]
            ) : _source(std::move(source)), IBasicCSVParser(format, col_names) {};


csv-parser/tests/test_csv_stat.cpp:58:22: error: implicit conversion loses floating-point precision: '__gnu_cxx::__alloc_traits<std::allocator<long double>, long double>::value_type' (aka 'long double') to 'double' [-Werror,-Wimplicit-float-conversion]
        REQUIRE(ceil(reader.get_variance()[0]) == 842);

csv-parser/tests/test_raw_csv_data.cpp:9:7: error: declaration shadows a type alias in namespace 'csv' [-Werror,-Wshadow]
using RowCollection = ThreadSafeDeque<CSVRow>;

csv-parser/single_include_test/csv.hpp:7027:39: error: moving a temporary object prevents copy elision [-Werror,-Wpessimizing-move]
        CSVReader::iterator ret(this, std::move(this->records->pop_front()));

csv-parser/single_include_test/csv.hpp:7733:36: error: implicit conversion from 'size_t' (aka 'unsigned long') to 'double' may lose precision [-Werror,-Wimplicit-int-float-conversion]
                if (result.score > max_score) {

csv-parser/single_include_test/csv.hpp:7926:23: error: moving a temporary object prevents copy elision [-Werror,-Wpessimizing-move]
                row = std::move(this->records->pop_front());
                      ^                   
```

#145 