### PR TITLE
fix CONSTEXPR for C++14 and GNUC

### DIFF
--- a/include/internal/common.hpp
+++ b/include/internal/common.hpp
@@ -89,14 +89,14 @@ namespace csv {
     using enable_if_t = typename std::enable_if<B, T>::type;
 #endif
 
+#ifdef CSV_HAS_CXX17
+#if defined __GNUC__ && !defined __clang__  // gcc
     // Resolves g++ bug with regard to constexpr methods
     // See: https://stackoverflow.com/questions/36489369/constexpr-non-static-member-function-with-non-constexpr-constructor-gcc-clang-d
-#if defined __GNUC__ && !defined __clang__
 #if (__GNUC__ >= 7 &&__GNUC_MINOR__ >= 2) || (__GNUC__ >= 8)
 #define CONSTEXPR constexpr
 #endif
-#else
-#ifdef CSV_HAS_CXX17
+#else  // clang
 #define CONSTEXPR constexpr
 #endif
 #endif

--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -4730,14 +4730,14 @@ namespace csv {
     using enable_if_t = typename std::enable_if<B, T>::type;
 #endif
 
+#ifdef CSV_HAS_CXX17
+#if defined __GNUC__ && !defined __clang__  // gcc
     // Resolves g++ bug with regard to constexpr methods
     // See: https://stackoverflow.com/questions/36489369/constexpr-non-static-member-function-with-non-constexpr-constructor-gcc-clang-d
-#if defined __GNUC__ && !defined __clang__
 #if (__GNUC__ >= 7 &&__GNUC_MINOR__ >= 2) || (__GNUC__ >= 8)
 #define CONSTEXPR constexpr
 #endif
-#else
-#ifdef CSV_HAS_CXX17
+#else  // clang
 #define CONSTEXPR constexpr
 #endif
 #endif


### PR DESCRIPTION
Issue: when using gcc >7.2 together with `CSV_CXX_STANDARD 11/14`, it would lead to `CONSTEXPR` evaluating to `constexpr` even though `C++17` is not used. This was due to a logic error when handling a bug in a specific version of gcc.

This issue only appears when using gcc. It works when using clang.