### PR TITLE
Clean up warnings about the type mismatch

### DIFF
--- a/include/internal/csv_row.cpp
+++ b/include/internal/csv_row.cpp
@@ -156,11 +156,11 @@ namespace csv {
                 return false;
             }
 
-            value += digit * pow(16, base16_exponent);
+            value += digit * static_cast<int>(pow(16, base16_exponent));
             base16_exponent--;
         }
 
-        parsedValue = value;
+        parsedValue = static_cast<int>(value);
         return true;
     }
 

--- a/include/internal/csv_row.cpp
+++ b/include/internal/csv_row.cpp
@@ -156,7 +156,7 @@ namespace csv {
                 return false;
             }
 
-            value += digit * static_cast<int>(pow(16, base16_exponent));
+            value += digit * static_cast<int>(pow(16, static_cast<int>(base16_exponent)));
             base16_exponent--;
         }
 

--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -7774,11 +7774,11 @@ namespace csv {
                 return false;
             }
 
-            value += digit * pow(16, base16_exponent);
+            value += digit * static_cast<int>(pow(16, base16_exponent));
             base16_exponent--;
         }
 
-        parsedValue = value;
+        parsedValue = static_cast<int>(value);
         return true;
     }
 

--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -7774,7 +7774,7 @@ namespace csv {
                 return false;
             }
 
-            value += digit * static_cast<int>(pow(16, base16_exponent));
+            value += digit * static_cast<int>(pow(16, static_cast<int>(base16_exponent)));
             base16_exponent--;
         }
 

--- a/single_include_test/csv.hpp
+++ b/single_include_test/csv.hpp
@@ -7774,11 +7774,11 @@ namespace csv {
                 return false;
             }
 
-            value += digit * pow(16, base16_exponent);
+            value += digit * static_cast<int>(pow(16, base16_exponent));
             base16_exponent--;
         }
 
-        parsedValue = value;
+        parsedValue = static_cast<int>(value);
         return true;
     }
 

--- a/single_include_test/csv.hpp
+++ b/single_include_test/csv.hpp
@@ -7774,7 +7774,7 @@ namespace csv {
                 return false;
             }
 
-            value += digit * static_cast<int>(pow(16, base16_exponent));
+            value += digit * static_cast<int>(pow(16, static_cast<int>(base16_exponent)));
             base16_exponent--;
         }
 


### PR DESCRIPTION
Clean up the type mismatch warnings to satisfy the compiler.