### PR TITLE
Avoid two msvc compiler warnings

### DIFF
--- a/include/internal/csv_row.cpp
+++ b/include/internal/csv_row.cpp
@@ -105,7 +105,7 @@ namespace csv {
         for (; start < this->sv.size() && this->sv[start] == ' '; start++);
         for (end = start; end < this->sv.size() && this->sv[end] != ' '; end++);
         
-        unsigned long long int value = 0;
+        unsigned long long int value_ = 0;
 
         size_t digits = (end - start);
         size_t base16_exponent = digits - 1;
@@ -156,11 +156,11 @@ namespace csv {
                 return false;
             }
 
-            value += digit * pow(16, base16_exponent);
+            value_ += digit * pow(16, base16_exponent);
             base16_exponent--;
         }
 
-        parsedValue = value;
+        parsedValue = value_;
         return true;
     }
 

--- a/include/internal/csv_row_json.cpp
+++ b/include/internal/csv_row_json.cpp
@@ -170,7 +170,7 @@ namespace csv {
                     if (c >= 0x00 && c <= 0x1f)
                     {
                         // print character c as \uxxxx
-                        sprintf_s(&result[pos + 1], result_size - pos - 1, "u%04x", int(c));
+                        snprintf(&result[pos + 1], result_size - pos - 1, "u%04x", int(c));
                         pos += 6;
                         // overwrite trailing null character
                         result[pos] = '\\';

--- a/include/internal/csv_row_json.cpp
+++ b/include/internal/csv_row_json.cpp
@@ -94,7 +94,8 @@ namespace csv {
             }
 
             // create a result string of necessary size
-            std::string result(s.size() + space, '\\');
+            size_t result_size = s.size() + space;
+            std::string result(result_size, '\\');
             std::size_t pos = 0;
 
             for (const auto& c : s)
@@ -169,7 +170,7 @@ namespace csv {
                     if (c >= 0x00 && c <= 0x1f)
                     {
                         // print character c as \uxxxx
-                        sprintf(&result[pos + 1], "u%04x", int(c));
+                        sprintf_s(&result[pos + 1], result_size - pos - 1, "u%04x", int(c));
                         pos += 6;
                         // overwrite trailing null character
                         result[pos] = '\\';


### PR DESCRIPTION
As part of pushing our codebase to zero warnings (warnings as errors) we came across these two warnings in this library and wanted to contribute our small modifications back. 

Confirmed all tests passing:
![image](https://user-images.githubusercontent.com/151124/229383377-633c8587-941e-4441-8589-b6b1df874d0d.png)
