### PR TITLE
Provide directory of library's header as the include directory

### DIFF
--- a/include/internal/CMakeLists.txt
+++ b/include/internal/CMakeLists.txt
@@ -25,3 +25,4 @@ target_sources(csv
 
 set_target_properties(csv PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(csv PRIVATE Threads::Threads)
+target_include_directories(csv INTERFACE ../)


### PR DESCRIPTION
Avoid having consumers need to know or declare internal structure of project.

E.g. a project that is using this library could then get the library using FetchContent_Declare

```cmake
FetchContent_Declare(
  csv  
  GIT_REPOSITORY https://github.com/vincentlaucsb/csv-parser.git
  GIT_SHALLOW TRUE 
  GIT_TAG 2.1.3 
) 
```

Then use the this library without having to worry about the specifics of where it's located.
```cmake
target_include_directories(my_project
  PUBLIC
    ${CMAKE_SOURCE_DIR}/include
  PRIVATE
    csv
) 

target_link_libraries(my_project PRIVATE csv)
```

This would also greatly simplify including this in an existing project as the user would not have to manually clone the repo as if it were part of the code base they're maintaining.