### PR TITLE
Fix invalid memory access issue in g++ builds

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -4,7 +4,7 @@ name: CMake on multiple platforms
 
 on:
   push:
-    branches: [ "master", "gcc-error" ]
+    branches: [ "master", "memory-fix-gcc" ]
   pull_request:
     branches: [ "master" ]
 

--- a/include/csv.hpp
+++ b/include/csv.hpp
@@ -1,5 +1,5 @@
 /*
-CSV for C++, version 2.2.1
+CSV for C++, version 2.2.2
 https://github.com/vincentlaucsb/csv-parser
 
 MIT License

--- a/include/internal/csv_row.cpp
+++ b/include/internal/csv_row.cpp
@@ -204,12 +204,7 @@ namespace csv {
     }
 
     CSV_INLINE CSVRow::iterator::pointer CSVRow::iterator::operator->() const {
-        // Using CSVField * as pointer type causes segfaults in MSVC debug builds
-        #ifdef _MSC_BUILD
         return this->field;
-        #else
-        return this->field.get();
-        #endif
     }
 
     CSV_INLINE CSVRow::iterator& CSVRow::iterator::operator++() {

--- a/include/internal/csv_row.hpp
+++ b/include/internal/csv_row.hpp
@@ -337,15 +337,7 @@ namespace csv {
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
             using value_type = CSVField;
             using difference_type = int;
-
-            // Using CSVField * as pointer type causes segfaults in MSVC debug builds
-            // but using shared_ptr as pointer type won't compile in g++
-#ifdef _MSC_BUILD
             using pointer = std::shared_ptr<CSVField>;
-#else
-            using pointer = CSVField * ;
-#endif
-
             using reference = CSVField & ;
             using iterator_category = std::random_access_iterator_tag;
 #endif

--- a/tests/test_csv_stat.cpp
+++ b/tests/test_csv_stat.cpp
@@ -4,6 +4,22 @@ using namespace csv;
 
 const std::string PERSONS_CSV = "./tests/data/mimesis_data/persons.csv";
 
+// Regression test for #208: Try to parse an empty file shouldn't result in a SEGFAULT
+TEST_CASE("Empty File", "[read_csv_stat_empty]") {
+    bool error_caught = false;
+
+    try {
+        CSVStat stats("./tests/data/fake_data/empty.csv");
+        stats.get_mins();
+    }
+    catch (std::runtime_error& err) {
+        error_caught = true;
+        REQUIRE(strcmp(err.what(), "Cannot open file ./tests/data/fake_data/empty.csv") == 0);
+    }
+
+    REQUIRE(error_caught);
+}
+
 TEST_CASE("Calculating Statistics from Direct Input", "[read_csv_stat_direct]" ) {
     std::string int_str;
     std::stringstream int_list;

--- a/tests/test_csv_stat.cpp
+++ b/tests/test_csv_stat.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include "catch.hpp"
 #include "csv.hpp"
 using namespace csv;


### PR DESCRIPTION
Fix invalid memory access issues in g++ builds caused when accessing `CSVField` methods while using the `CSVRow` reverse iterator.

This was caused by a workaround to previous versions of g++ not supporting the use of `std::shared_ptr` as a pointer type in iterators, thus requiring the fallback use of raw pointers (which would cause the `std::shared_ptr<CSVField>` to go out of scope and get deleted.

Now that newer versions of g++ don't have this problem, we can remove the dubious workaround.

![image](https://github.com/vincentlaucsb/csv-parser/assets/18455475/a86888c1-9da9-4fa3-883b-34a70c9276eb)
