### PR TITLE
Remove -WError flag from Linix build

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -4,7 +4,7 @@ name: CMake on multiple platforms
 
 on:
   push:
-    branches: [ "master", "memory-fix-gcc" ]
+    branches: [ "master", "remove-werror" ]
   pull_request:
     branches: [ "master" ]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ if (CSV_DEVELOPER)
     # More error messages.
     if (UNIX)
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
-        -Wall -Werror -Wextra -Wsign-compare \
+        -Wall -Wextra -Wsign-compare \
         -Wwrite-strings -Wpointer-arith -Winit-self \
         -Wconversion -Wno-sign-conversion")
     endif()


### PR DESCRIPTION
Was preventing the integration of the updated Catch2 library