### PR TITLE
Replace the includes of Windows.h with windows.h (#204)

### DIFF
--- a/include/internal/common.hpp
+++ b/include/internal/common.hpp
@@ -13,7 +13,7 @@
 # ifndef WIN32_LEAN_AND_MEAN
 #  define WIN32_LEAN_AND_MEAN
 # endif
-# include <Windows.h>
+# include <windows.h>
 # undef max
 # undef min
 #elif defined(__linux__)

--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -1831,7 +1831,7 @@ using shared_ummap_sink = basic_shared_mmap_sink<unsigned char>;
 # ifndef WIN32_LEAN_AND_MEAN
 #  define WIN32_LEAN_AND_MEAN
 # endif
-# include <Windows.h>
+# include <windows.h>
 # undef max
 # undef min
 #elif defined(__linux__)

--- a/single_include_test/csv.hpp
+++ b/single_include_test/csv.hpp
@@ -1831,7 +1831,7 @@ using shared_ummap_sink = basic_shared_mmap_sink<unsigned char>;
 # ifndef WIN32_LEAN_AND_MEAN
 #  define WIN32_LEAN_AND_MEAN
 # endif
-# include <Windows.h>
+# include <windows.h>
 # undef max
 # undef min
 #elif defined(__linux__)


### PR DESCRIPTION
When cross-compiling with MinGW, the compiler is unable to find the include of Windows.h because windows.h is provided instead. Replacing the includes of Windows.h with windows.h solves the issue and still works on Windows because the filesystem is case insensitive.
This is what is already done in include/external/mio.hpp.