### PR TITLE
Use correct floating point precision

### DIFF
--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -8321,8 +8321,8 @@ namespace csv {
                 counts.push_back({});
                 rolling_means.push_back(0);
                 rolling_vars.push_back(0);
-                mins.push_back(NAN);
-                maxes.push_back(NAN);
+                mins.push_back(std::numeric_limits<long double>::quiet_NaN());
+                maxes.push_back(std::numeric_limits<long double>::quiet_NaN());
                 n.push_back(0);
             }
         }


### PR DESCRIPTION
Clang20 warns about :

**Use of NaN via a macro is undefined behavior due to the currently enabled floating-point optionsclang(-Wnan-infinity-disabled)**

This modification use the required floating point precision