### PR TITLE
Fix C++ standard detection macros to check for defined value

### DIFF
--- a/include/internal/common.hpp
+++ b/include/internal/common.hpp
@@ -54,11 +54,11 @@ namespace csv {
 
 #define STATIC_ASSERT(x) static_assert(x, "Assertion failed")
 
-#if CMAKE_CXX_STANDARD == 17 || __cplusplus >= 201703L
+#if (defined(CMAKE_CXX_STANDARD) && CMAKE_CXX_STANDARD == 17) || __cplusplus >= 201703L
 #define CSV_HAS_CXX17
 #endif
 
-#if CMAKE_CXX_STANDARD >= 14 || __cplusplus >= 	201402L
+#if (defined(CMAKE_CXX_STANDARD) && CMAKE_CXX_STANDARD >= 14) || __cplusplus >= 201402L
 #define CSV_HAS_CXX14
 #endif
 

--- a/single_include/csv.hpp
+++ b/single_include/csv.hpp
@@ -4695,11 +4695,11 @@ namespace csv {
 
 #define STATIC_ASSERT(x) static_assert(x, "Assertion failed")
 
-#if CMAKE_CXX_STANDARD == 17 || __cplusplus >= 201703L
+#if (defined(CMAKE_CXX_STANDARD) && CMAKE_CXX_STANDARD == 17) || __cplusplus >= 201703L
 #define CSV_HAS_CXX17
 #endif
 
-#if CMAKE_CXX_STANDARD >= 14 || __cplusplus >= 	201402L
+#if (defined(CMAKE_CXX_STANDARD) && CMAKE_CXX_STANDARD >= 14) || __cplusplus >= 201402L
 #define CSV_HAS_CXX14
 #endif
 

--- a/single_include_test/csv.hpp
+++ b/single_include_test/csv.hpp
@@ -4695,11 +4695,11 @@ namespace csv {
 
 #define STATIC_ASSERT(x) static_assert(x, "Assertion failed")
 
-#if CMAKE_CXX_STANDARD == 17 || __cplusplus >= 201703L
+#if (defined(CMAKE_CXX_STANDARD) && CMAKE_CXX_STANDARD == 17) || __cplusplus >= 201703L
 #define CSV_HAS_CXX17
 #endif
 
-#if CMAKE_CXX_STANDARD >= 14 || __cplusplus >= 	201402L
+#if (defined(CMAKE_CXX_STANDARD) && CMAKE_CXX_STANDARD >= 14) || __cplusplus >= 201402L
 #define CSV_HAS_CXX14
 #endif
 


### PR DESCRIPTION
This PR updates the C++ standard detection macros to first check if CMAKE_CXX_STANDARD is defined before comparing its value. This prevents build errors when CMAKE_CXX_STANDARD is undefined.

I found that the current macro causes build failures on some setups, especially when the variable is not set, resulting in errors like 'CMAKE_CXX_STANDARD not defined'. 

I haven’t tested the full build due to unrelated build errors on master, but this is a low-risk fix that corrects the macro guard logic.