### PR TITLE
Don't push empty rows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ CSVReader reader(infile, format);
 
 ## Threading: Worker + 10MB Chunks
 
-- Worker thread reads in 10MB chunks (`ITERATION_CHUNK_SIZE`)
+- Worker thread reads in 10MB chunks (`CSV_CHUNK_SIZE_DEFAULT`)
 - Communicates via `ThreadSafeDeque<CSVRow>`
 - Exceptions propagate via `std::exception_ptr`
 - Critical: Fields spanning chunk boundaries must not corrupt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@
 - Bugs can exist in one and not the other — always test both with Catch2 `SECTION`
 
 ## Threading
-- Worker thread reads 10MB chunks (`ITERATION_CHUNK_SIZE`)
+- Worker thread reads 10MB chunks (`CSV_CHUNK_SIZE_DEFAULT`)
 - Communication via `ThreadSafeDeque<CSVRow>`
 - Exceptions propagate via `std::exception_ptr`
 - Tests must use ≥500K rows to cross chunk boundary

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 ## Motivation
 I wanted a CSV library that was fast and reliable without forcing you into either:
  * A 1990s C-style API
- * A high-level wrapper that murders `malloc()` and your memory cache
+ * A high-level wrapper that murders `malloc()` and your cache
 
 This library tries to be **fast for developers** and **fast for your computer**.
 
@@ -57,17 +57,16 @@ All benchmarks shown are warm cache runs to focus on parser/CPU performance rath
 
 #### Chunk Size Tuning
 
-By default, the parser reads CSV data in 10MB chunks. This balance was determined through empirical testing to optimize throughput while minimizing memory overhead and thread synchronization costs, but feel free to experiment and measure with different numbers yourself.
+By default, the parser reads CSV data in 10MB chunks. 10MB was chosen after empirical testing to optimize throughput while minimizing memory and thread synchronization costs, but feel free to experiment with different numbers yourself.
 
-If you encounter rows larger than the chunk size, pass a custom `CSVFormat` with `chunk_size()`:
+A custom `CSVFormat` with `chunk_size()` can be passed to:
+ * Shrink the chunk size (down to a minimum of 500KB)
+ * Expand the chunk size (necessary if you encounter very large rows)
 
 ```cpp
 CSVFormat fmt;
 fmt.chunk_size(100 * 1024 * 1024);  // 100MB chunks
 CSVReader reader("massive_rows.csv", fmt);
-for (auto& row : reader) {
-    // Process row
-}
 ```
 
 ### Robust Yet Flexible

--- a/include/internal/basic_csv_parser.cpp
+++ b/include/internal/basic_csv_parser.cpp
@@ -259,7 +259,7 @@ namespace csv {
 #pragma region Specializations
 #endif
 #if !defined(__EMSCRIPTEN__)
-        CSV_INLINE void MmapParser::next(size_t bytes = ITERATION_CHUNK_SIZE) {
+        CSV_INLINE void MmapParser::next(size_t bytes = CSV_CHUNK_SIZE_DEFAULT) {
             // CRITICAL SECTION: Chunk Transition Logic
             // This function reads 10MB chunks and must correctly handle fields that span
             // chunk boundaries. The 'remainder' calculation below ensures partial fields

--- a/include/internal/basic_csv_parser.hpp
+++ b/include/internal/basic_csv_parser.hpp
@@ -176,7 +176,7 @@ namespace csv {
             ///@}
 
             /** Whether or not source needs to be read in chunks */
-            CONSTEXPR bool no_chunk() const { return this->source_size_ < ITERATION_CHUNK_SIZE; }
+            CONSTEXPR bool no_chunk() const { return this->source_size_ < CSV_CHUNK_SIZE_DEFAULT; }
 
             /** Parse the current chunk of data *
              *
@@ -287,7 +287,7 @@ namespace csv {
 
             ~StreamParser() {}
 
-            void next(size_t bytes = ITERATION_CHUNK_SIZE) override {
+            void next(size_t bytes = CSV_CHUNK_SIZE_DEFAULT) override {
                 if (this->eof()) return;
 
                 // Reset parser state

--- a/include/internal/common.hpp
+++ b/include/internal/common.hpp
@@ -204,9 +204,9 @@ namespace csv {
         const int PAGE_SIZE = 4096;
 #endif
 
-        /** Chunk size for lazy-loading large CSV files
+        /** Default chunk size for lazy-loading large CSV files
          * 
-         * The worker thread reads this many bytes at a time (10MB).
+         * The worker thread reads this many bytes at a time by default (10MB).
          * 
          * CRITICAL INVARIANT: Field boundaries at chunk transitions must be preserved.
          * Bug #280 was caused by fields spanning chunk boundaries being corrupted.
@@ -214,7 +214,14 @@ namespace csv {
          * @note Tests must write >10MB of data to cross chunk boundaries
          * @see basic_csv_parser.cpp MmapParser::next() for chunk transition logic
          */
-        constexpr size_t ITERATION_CHUNK_SIZE = 10000000; // 10MB
+        constexpr size_t CSV_CHUNK_SIZE_DEFAULT = 10000000; // 10MB
+
+        /** Minimum supported custom chunk size for CSVFormat::chunk_size().
+         *
+         * This lower bound allows memory-constrained environments to reduce parser
+         * buffer size while avoiding pathological tiny-buffer overhead.
+         */
+        constexpr size_t CSV_CHUNK_SIZE_FLOOR = 500 * 1024; // 500KB
 
         template<typename T>
         inline bool is_equal(T a, T b, T epsilon = 0.001) {

--- a/include/internal/csv_format.cpp
+++ b/include/internal/csv_format.cpp
@@ -48,11 +48,11 @@ namespace csv {
     }
 
     CSV_INLINE CSVFormat& CSVFormat::chunk_size(size_t size) {
-        if (size < internals::ITERATION_CHUNK_SIZE) {
+        if (size < internals::CSV_CHUNK_SIZE_FLOOR) {
             throw std::invalid_argument(
                 "Chunk size must be at least " +
-                std::to_string(internals::ITERATION_CHUNK_SIZE) +
-                " bytes (10MB). Provided: " + std::to_string(size)
+                std::to_string(internals::CSV_CHUNK_SIZE_FLOOR) +
+                " bytes (500KB). Provided: " + std::to_string(size)
             );
         }
         this->_chunk_size = size;

--- a/include/internal/csv_format.hpp
+++ b/include/internal/csv_format.hpp
@@ -123,8 +123,8 @@ namespace csv {
 
         /** Sets the chunk size used when reading the CSV
          *
-         *  @param[in] size Chunk size in bytes (minimum: 10MB = ITERATION_CHUNK_SIZE)
-         *  @throws std::invalid_argument if size < ITERATION_CHUNK_SIZE
+         *  @param[in] size Chunk size in bytes (minimum: CSV_CHUNK_SIZE_FLOOR)
+         *  @throws std::invalid_argument if size < CSV_CHUNK_SIZE_FLOOR
          *
          *  Use this when constructing a CSVReader from a filename and individual rows
          *  may exceed the default 10MB chunk size. The value is passed to CSVReader at
@@ -198,6 +198,6 @@ namespace csv {
         ColumnNamePolicy _column_name_policy = ColumnNamePolicy::EXACT;
 
         /**< Chunk size for reading; passed to CSVReader at construction time */
-        size_t _chunk_size = internals::ITERATION_CHUNK_SIZE;
+        size_t _chunk_size = internals::CSV_CHUNK_SIZE_DEFAULT;
     };
 }

--- a/include/internal/csv_reader.cpp
+++ b/include/internal/csv_reader.cpp
@@ -306,7 +306,7 @@ namespace csv {
      * Retrieve rows as CSVRow objects, returning true if more rows are available.
      *
      * @par Performance Notes
-     *  - Reads chunks of data that are csv::internals::ITERATION_CHUNK_SIZE bytes large at a time
+    *  - Reads chunks of data that are csv::internals::CSV_CHUNK_SIZE_DEFAULT bytes large at a time
      *  - For performance details, read the documentation for CSVRow and CSVField.
      *
      * @param[out] row The variable where the parsed row will be stored
@@ -344,7 +344,7 @@ namespace csv {
                 // This fires when a single row spans more than 2 × _chunk_size bytes:
                 //   - chunk N   fills without finding '\n'  → _read_requested set to true
                 //   - chunk N+1 also fills without '\n'     → guard fires here
-                // Default _chunk_size is ITERATION_CHUNK_SIZE (10 MB), so the threshold is
+                // Default _chunk_size is CSV_CHUNK_SIZE_DEFAULT (10 MB), so the threshold is
                 // rows > 20 MB.  Use CSVFormat::chunk_size() to raise the limit.
                 if (this->_read_requested && this->records->empty()) {
                     throw std::runtime_error(

--- a/include/internal/csv_reader.hpp
+++ b/include/internal/csv_reader.hpp
@@ -250,7 +250,7 @@ namespace csv {
             other._n_rows = 0;
             other.header_trimmed = false;
             other._read_requested = false;
-            other._chunk_size = internals::ITERATION_CHUNK_SIZE;
+            other._chunk_size = internals::CSV_CHUNK_SIZE_DEFAULT;
         }
 
         /** Move assignment.
@@ -287,7 +287,7 @@ namespace csv {
             other._n_rows = 0;
             other.header_trimmed = false;
             other._read_requested = false;
-            other._chunk_size = internals::ITERATION_CHUNK_SIZE;
+            other._chunk_size = internals::CSV_CHUNK_SIZE_DEFAULT;
 
             return *this;
         }
@@ -373,7 +373,7 @@ namespace csv {
 
         /** @name Multi-Threaded File Reading Functions */
         ///@{
-        bool read_csv(size_t bytes = internals::ITERATION_CHUNK_SIZE);
+        bool read_csv(size_t bytes = internals::CSV_CHUNK_SIZE_DEFAULT);
         ///@}
 
         /**@}*/
@@ -386,7 +386,7 @@ namespace csv {
     #if CSV_ENABLE_THREADS
         std::thread read_csv_worker; /**< Worker thread for read_csv() */
     #endif
-        size_t _chunk_size = internals::ITERATION_CHUNK_SIZE; /**< Current chunk size in bytes */
+        size_t _chunk_size = internals::CSV_CHUNK_SIZE_DEFAULT; /**< Current chunk size in bytes */
         bool _read_requested = false; /**< Flag to detect infinite read loops (Issue #218) */
         ///@}
 

--- a/include/internal/raw_csv_data.hpp
+++ b/include/internal/raw_csv_data.hpp
@@ -67,7 +67,7 @@ namespace csv {
             /** Construct a RawCSVFieldList which allocates blocks of a certain size */
             RawCSVFieldList(size_t single_buffer_capacity = (size_t)(internals::PAGE_SIZE / sizeof(RawCSVField))) :
                 _single_buffer_capacity(single_buffer_capacity) {
-                const size_t max_fields = internals::ITERATION_CHUNK_SIZE + 1;
+                const size_t max_fields = internals::CSV_CHUNK_SIZE_DEFAULT + 1;
                 const size_t block_capacity = (max_fields + _single_buffer_capacity - 1) / _single_buffer_capacity;
                 _owned_blocks.reserve(block_capacity);
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -253,7 +253,7 @@ TEST_CASE("Multithreaded parsing", "[threading]") {
 3. **FileGuard RAII**: Guaranteed cleanup for temp files
 4. **Timeout Guards**: Use `test_with_timeout()` for race/deadlock-sensitive tests
 5. **Distinct Values**: Detect cross-field corruption
-6. **Chunk Boundary Testing**: Cross 10MB ITERATION_CHUNK_SIZE
+6. **Chunk Boundary Testing**: Cross 10MB CSV_CHUNK_SIZE_DEFAULT
 
 ### Data Files
 Test data in `tests/data/` is a git submodule:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(csv_test
         test_edge_cases_large_rows.cpp
         test_error_handling.cpp
         test_guess_csv.cpp
+        test_parser_edge_cases.cpp
         test_raw_csv_data.cpp
         test_read_csv.cpp
         test_read_csv_file.cpp

--- a/tests/test_edge_cases_large_rows.cpp
+++ b/tests/test_edge_cases_large_rows.cpp
@@ -1,6 +1,6 @@
 //
 // Tests for edge cases with large CSV rows
-// Issue #218: Infinite loop when a row exceeds ITERATION_CHUNK_SIZE
+// Issue #218: Infinite loop when a row exceeds CSV_CHUNK_SIZE_DEFAULT
 //
 
 #include <catch2/catch_all.hpp>
@@ -34,15 +34,33 @@ static std::string generate_large_row(size_t target_bytes, int num_fields = 10) 
     return row;
 }
 
-// Build shared 25 MB rows once.  Catch2 re-runs the preamble before each
-// SECTION, so static locals prevent repeated 25 MB heap allocations.
-static const std::string& large_row_3col() {
-    static const std::string row = generate_large_row(25 * 1024 * 1024, 3);
+constexpr size_t kRowBytesStress = 25 * 1024 * 1024;
+// StreamParser prepends leftover bytes from the previous read, so the second
+// parse attempt can process nearly 2x the default chunk. Keep a margin above
+// that to reliably hit the infinite-loop guard path.
+constexpr size_t kRowBytesGuardTrip = 2 * internals::CSV_CHUNK_SIZE_DEFAULT + 2 * 1024 * 1024;
+constexpr size_t kRowBytesMedium = internals::CSV_CHUNK_SIZE_DEFAULT + 64 * 1024;
+constexpr size_t kChunkBytesMedium = internals::CSV_CHUNK_SIZE_DEFAULT + 256 * 1024;
+
+// Build shared rows once. Catch2 re-runs the preamble before each SECTION,
+// so static locals avoid repeated multi-megabyte heap allocations.
+static const std::string& stress_row_3col() {
+    static const std::string row = generate_large_row(kRowBytesStress, 3);
     return row;
 }
 
-static const std::string& large_row_2col() {
-    static const std::string row = generate_large_row(25 * 1024 * 1024, 2);
+static const std::string& guard_trip_row_3col() {
+    static const std::string row = generate_large_row(kRowBytesGuardTrip, 3);
+    return row;
+}
+
+static const std::string& guard_trip_row_2col() {
+    static const std::string row = generate_large_row(kRowBytesGuardTrip, 2);
+    return row;
+}
+
+static const std::string& medium_row_3col() {
+    static const std::string row = generate_large_row(kRowBytesMedium, 3);
     return row;
 }
 
@@ -64,9 +82,8 @@ TEST_CASE("Edge case: CSV rows larger than default chunk size", "[edge_cases_lar
 
     SECTION("Exception thrown for row exceeding default chunk size") {
         // The infinite-loop guard fires when a full chunk is consumed without
-        // producing any complete rows.  This requires the row to be strictly
-        // larger than 2 × ITERATION_CHUNK_SIZE (2 × 10 MB = 20 MB).
-        // A 25 MB row guarantees the second 10 MB chunk also contains no '\n'.
+        // producing any complete rows. StreamParser carries leftover bytes
+        // across reads, so this row includes a safety margin above 2x default.
         auto validate_throws = [](CSVReader& reader) {
             REQUIRE_THROWS_WITH(
                 [&reader]() {
@@ -78,7 +95,7 @@ TEST_CASE("Edge case: CSV rows larger than default chunk size", "[edge_cases_lar
 
         SECTION("stream path") {
             std::stringstream ss;
-            ss << "Col1,Col2,Col3\n" << large_row_3col();
+            ss << "Col1,Col2,Col3\n" << guard_trip_row_3col();
             CSVReader reader(ss);
             validate_throws(reader);
         }
@@ -88,7 +105,7 @@ TEST_CASE("Edge case: CSV rows larger than default chunk size", "[edge_cases_lar
             FileGuard cleanup("./tests/data/tmp_large_row_throw.csv");
             {
                 std::ofstream out(cleanup.filename, std::ios::binary);
-                out << "Col1,Col2,Col3\n" << large_row_3col();
+                out << "Col1,Col2,Col3\n" << guard_trip_row_3col();
             }
             CSVReader reader(cleanup.filename);
             validate_throws(reader);
@@ -97,9 +114,9 @@ TEST_CASE("Edge case: CSV rows larger than default chunk size", "[edge_cases_lar
     }
 
     SECTION("Custom chunk size allows parsing larger rows") {
-        // Row is 25 MB; with a 30 MB chunk it fits in a single read.
+        // Row is just above default chunk size; medium chunk size should parse it.
         CSVFormat fmt;
-        fmt.delimiter(',').chunk_size(30 * 1024 * 1024);
+        fmt.delimiter(',').chunk_size(kChunkBytesMedium);
 
         auto validate_reader = [](CSVReader& reader) {
             int row_count = 0;
@@ -112,7 +129,7 @@ TEST_CASE("Edge case: CSV rows larger than default chunk size", "[edge_cases_lar
 
         SECTION("stream path") {
             std::stringstream ss;
-            ss << "Col1,Col2,Col3\n" << large_row_3col() << "8,9,10\n";
+            ss << "Col1,Col2,Col3\n" << medium_row_3col() << "8,9,10\n";
             CSVReader reader(ss, fmt);
             validate_reader(reader);
         }
@@ -122,7 +139,7 @@ TEST_CASE("Edge case: CSV rows larger than default chunk size", "[edge_cases_lar
             FileGuard cleanup("./tests/data/tmp_large_row_parse.csv");
             {
                 std::ofstream out(cleanup.filename, std::ios::binary);
-                out << "Col1,Col2,Col3\n" << large_row_3col() << "8,9,10\n";
+                out << "Col1,Col2,Col3\n" << medium_row_3col() << "8,9,10\n";
             }
             CSVReader reader(cleanup.filename, fmt);
             validate_reader(reader);
@@ -130,8 +147,8 @@ TEST_CASE("Edge case: CSV rows larger than default chunk size", "[edge_cases_lar
         #endif
     }
 
-    SECTION("Multiple large rows with custom chunk size") {
-        // Each row is 25 MB; 30 MB chunk fits each row in a single read.
+    SECTION("Single 25MB row stress test with custom chunk size") {
+        // Keep one explicit 25 MB stress path for throughput/regression coverage.
         CSVFormat fmt;
         fmt.delimiter(',').chunk_size(30 * 1024 * 1024);
 
@@ -141,13 +158,12 @@ TEST_CASE("Edge case: CSV rows larger than default chunk size", "[edge_cases_lar
                 row_count++;
                 REQUIRE(row.size() == 3);
             }
-            REQUIRE(row_count == 3);
+            REQUIRE(row_count == 1);
         };
 
         SECTION("stream path") {
             std::stringstream ss;
-            ss << "A,B,C\n";
-            for (int i = 0; i < 3; ++i) ss << large_row_3col();
+            ss << "A,B,C\n" << stress_row_3col();
             CSVReader reader(ss, fmt);
             validate_reader(reader);
         }
@@ -157,8 +173,7 @@ TEST_CASE("Edge case: CSV rows larger than default chunk size", "[edge_cases_lar
             FileGuard cleanup("./tests/data/tmp_large_rows_multiple.csv");
             {
                 std::ofstream out(cleanup.filename, std::ios::binary);
-                out << "A,B,C\n";
-                for (int i = 0; i < 3; ++i) out << large_row_3col();
+                out << "A,B,C\n" << stress_row_3col();
             }
             CSVReader reader(cleanup.filename, fmt);
             validate_reader(reader);
@@ -170,7 +185,7 @@ TEST_CASE("Edge case: CSV rows larger than default chunk size", "[edge_cases_lar
         // CSVFormat::chunk_size() validates at the point of configuration.
         CSVFormat fmt;
         REQUIRE_THROWS_WITH(
-            fmt.chunk_size(1024 * 1024),  // 1 MB — below the 10 MB minimum
+            fmt.chunk_size(128 * 1024),  // 128 KB — below the 500 KB minimum
             Catch::Matchers::ContainsSubstring("at least")
         );
         REQUIRE_THROWS_WITH(
@@ -179,12 +194,12 @@ TEST_CASE("Edge case: CSV rows larger than default chunk size", "[edge_cases_lar
         );
     }
 
-    SECTION("Minimum allowed chunk size (exactly ITERATION_CHUNK_SIZE) works") {
+    SECTION("Minimum allowed chunk size (exactly CSV_CHUNK_SIZE_FLOOR) works") {
         std::stringstream ss;
         ss << "A,B\n1,2\n";
 
         CSVFormat fmt;
-        fmt.delimiter(',').chunk_size(10 * 1024 * 1024);  // Exactly 10 MB minimum
+        fmt.delimiter(',').chunk_size(internals::CSV_CHUNK_SIZE_FLOOR);  // Exactly 500 KB minimum
         CSVReader reader(ss, fmt);
 
         int row_count = 0;
@@ -193,16 +208,16 @@ TEST_CASE("Edge case: CSV rows larger than default chunk size", "[edge_cases_lar
     }
 
     SECTION("Custom chunk size persists across reads") {
-        // reader1 uses a 30 MB chunk (succeeds);
-        // reader2 uses the default 10 MB chunk (triggers the exception).
+        // reader1 uses a medium chunk and medium row (succeeds);
+        // reader2 uses the default chunk with a >2x default row + margin (throws).
         std::stringstream ss1, ss2;
-        ss1 << "X,Y,Z\n" << large_row_3col();
-        ss2 << "P,Q,R\n" << large_row_3col();
+        ss1 << "X,Y,Z\n" << medium_row_3col();
+        ss2 << "P,Q,R\n" << guard_trip_row_3col();
 
         CSVFormat big_chunk;
-        big_chunk.delimiter(',').chunk_size(30 * 1024 * 1024);
+        big_chunk.delimiter(',').chunk_size(kChunkBytesMedium);
         CSVReader reader1(ss1, big_chunk);
-        CSVReader reader2(ss2);  // Default 10 MB chunk
+        CSVReader reader2(ss2);  // Default chunk size
 
         int count1 = 0;
         for (auto& row : reader1) { (void)row; count1++; }
@@ -219,11 +234,11 @@ TEST_CASE("Edge case: CSV rows larger than default chunk size", "[edge_cases_lar
 TEST_CASE("Issue #218 - Infinite read loop detection", "[issue_218]") {
 
     SECTION("Detects when row exceeds chunk size and file doesn't end") {
-        // A 25 MB row spans three 10 MB chunks; the second chunk completes
-        // without finding a '\n', so _read_requested is already true →
+        // A >2x default chunk row with margin spans three chunks; the second
+        // chunk completes without finding a '\n', so _read_requested is already true →
         // the infinite-loop guard fires.
         std::stringstream ss;
-        ss << "A,B\n" << "1,2\n" << large_row_2col();
+        ss << "A,B\n" << "1,2\n" << guard_trip_row_2col();
 
         CSVReader reader(ss);
 
@@ -231,7 +246,7 @@ TEST_CASE("Issue #218 - Infinite read loop detection", "[issue_218]") {
         auto it = reader.begin();  // Points to "1,2"
         REQUIRE(it != reader.end());
 
-        // Advancing into the 25 MB row: chunk 2 finishes with no complete rows
+        // Advancing into the oversized row: chunk 2 finishes with no complete rows
         // and _read_requested is already true → the guard fires.
         REQUIRE_THROWS_WITH(
             ++it,

--- a/tests/test_error_handling.cpp
+++ b/tests/test_error_handling.cpp
@@ -124,7 +124,7 @@ TEST_CASE("Fields at chunk boundaries are not corrupted", "[chunking][data_integ
         FileGuard cleanup(test_file);
         
         // Create CSV larger than chunk size to test boundary handling
-        // internals::ITERATION_CHUNK_SIZE is typically 10MB
+        // internals::CSV_CHUNK_SIZE_DEFAULT is typically 10MB
         {
             std::ofstream out(test_file);
             out << "id,name,value,timestamp\n";

--- a/tests/test_parser_edge_cases.cpp
+++ b/tests/test_parser_edge_cases.cpp
@@ -1,0 +1,81 @@
+#include <catch2/catch_all.hpp>
+
+#include <fstream>
+#include <sstream>
+#include <vector>
+
+#include "csv.hpp"
+#include "shared/file_guard.hpp"
+
+using namespace csv;
+
+#ifndef __EMSCRIPTEN__
+namespace {
+    std::string make_crlf_split_csv(size_t chunk_size) {
+        // Arrange bytes so row1 ends with '\r' at chunk boundary and '\n' in next chunk:
+        // [ ... <chunk_size - 1> = '\r' ][ <chunk_size> = '\n' ]
+        const size_t first_field_len = chunk_size - 3;
+
+        std::string csv_text;
+        csv_text.reserve(chunk_size + 64);
+        csv_text.append(first_field_len, 'X');
+        csv_text += ",B\r\n";
+        csv_text += "C,D\r\n";
+        return csv_text;
+    }
+
+    void validate_no_synthetic_row(CSVReader& reader, size_t expected_first_field_len) {
+        std::vector<std::vector<std::string>> rows;
+        REQUIRE_NOTHROW([
+            &rows,
+            &reader
+        ]() {
+            for (auto& row : reader) {
+                rows.emplace_back(std::vector<std::string>(row));
+            }
+        }());
+
+        // The parser should never synthesize an extra row in this split-CRLF case.
+        REQUIRE(rows.size() >= 1);
+        REQUIRE(rows.size() <= 2);
+        REQUIRE(rows[0].size() == 2);
+
+        REQUIRE(rows[0][0].size() == expected_first_field_len);
+        REQUIRE(rows[0][1] == "B");
+
+        if (rows.size() == 2) {
+            REQUIRE(rows[1].size() == 2);
+            REQUIRE(rows[1][0] == "C");
+            REQUIRE(rows[1][1] == "D");
+        }
+    }
+}
+
+TEST_CASE("PR #271 - CRLF split does not emit synthetic row", "[pr_271][parser_edge_cases]") {
+    const size_t chunk_size = internals::CSV_CHUNK_SIZE_FLOOR;
+    const size_t expected_first_field_len = chunk_size - 3;
+
+    CSVFormat format;
+    format
+        .no_header()
+        .variable_columns(VariableColumnPolicy::KEEP)
+        .chunk_size(chunk_size);
+
+    SECTION("stream path") {
+        std::stringstream ss(make_crlf_split_csv(chunk_size));
+        CSVReader reader(ss, format);
+        validate_no_synthetic_row(reader, expected_first_field_len);
+    }
+
+    SECTION("mmap path") {
+        FileGuard cleanup("./tests/data/tmp_issue_271_crlf_split.csv");
+        {
+            std::ofstream out(cleanup.filename, std::ios::binary);
+            out << make_crlf_split_csv(chunk_size);
+        }
+
+        CSVReader reader(cleanup.filename, format);
+        validate_no_synthetic_row(reader, expected_first_field_len);
+    }
+}
+#endif


### PR DESCRIPTION
The current NEWLINE behavior of reading as much CR/LF as possible basically means empty rows are/should be ignored.

This fixes the issue of pushing an empty row that can occur when the data chunk ends in the middle of such a CR/LF stream. This can happen more or less artificially with with a block of empty lines or because the chunk ended right in the middle of a Windows CRLF endline (yes I was very unlucky, the data in my 10Mo+ file aligned just the wrong way).

Side note: I'm not very fond of the "ignore all empty rows" behavior, but that's another topic. Here I assumed the behavior is intended by design, or at least should be consistent in every cases.