### PR TITLE
Updated cmake_minimum_required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.10)
 project(csv)
 
 if(CSV_CXX_STANDARD)


### PR DESCRIPTION
Updated cmake_minimum_required because Compatibility with CMake < 3.10 will be removed from a future version of CMake.