### PR TITLE
Added SIMD optimizations + tests

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -176,14 +176,18 @@ jobs:
         simd_mode: [avx2, sse2, no-simd]
         include:
           - simd_mode: avx2
-            cxx_flags: "-mavx2"
+            # Auto-detection will find AVX2 on GitHub's ubuntu-latest runners.
+            # Pass no extra flags; the build system selects -mavx2 automatically.
             cmake_no_simd: "OFF"
+            cmake_extra_flags: ""
           - simd_mode: sse2
-            cxx_flags: ""
+            # Force SSE2-only path by disabling auto-detected AVX2.
+            # -mno-avx2 prevents __AVX2__ from being defined so the SSE2 branch compiles.
             cmake_no_simd: "OFF"
+            cmake_extra_flags: "-DCMAKE_CXX_FLAGS=-mno-avx2"
           - simd_mode: no-simd
-            cxx_flags: ""
             cmake_no_simd: "ON"
+            cmake_extra_flags: ""
 
     steps:
     - name: Checkout repository and submodules
@@ -200,7 +204,7 @@ jobs:
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_CXX_COMPILER=g++
         -DCMAKE_C_COMPILER=gcc
-        -DCMAKE_CXX_FLAGS=${{ matrix.cxx_flags }}
+        ${{ matrix.cmake_extra_flags }}
         -S ${{ github.workspace }}
 
     - name: Build (${{ matrix.simd_mode }})

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -166,5 +166,49 @@ jobs:
       if: env.CSV_EMSCRIPTEN_RUN_TESTS != '1'
       run: echo "Skipping Emscripten ctest (build-only coverage). Set CSV_EMSCRIPTEN_RUN_TESTS=1 to re-enable."
 
+  simd-branches:
+    name: SIMD branch verification (${{ matrix.simd_mode }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        simd_mode: [avx2, sse2, no-simd]
+        include:
+          - simd_mode: avx2
+            cxx_flags: "-mavx2"
+            cmake_no_simd: "OFF"
+          - simd_mode: sse2
+            cxx_flags: ""
+            cmake_no_simd: "OFF"
+          - simd_mode: no-simd
+            cxx_flags: ""
+            cmake_no_simd: "ON"
+
+    steps:
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v5
+      with:
+        submodules: recursive
+
+    - name: Configure CMake (${{ matrix.simd_mode }})
+      run: >
+        cmake -B ${{ github.workspace }}/build-simd-${{ matrix.simd_mode }}
+        -DCSV_CXX_STANDARD=20
+        -DCSV_ENABLE_THREADS=ON
+        -DCSV_NO_SIMD=${{ matrix.cmake_no_simd }}
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_CXX_COMPILER=g++
+        -DCMAKE_C_COMPILER=gcc
+        -DCMAKE_CXX_FLAGS=${{ matrix.cxx_flags }}
+        -S ${{ github.workspace }}
+
+    - name: Build (${{ matrix.simd_mode }})
+      run: cmake --build ${{ github.workspace }}/build-simd-${{ matrix.simd_mode }} --config Release
+
+    - name: Test (${{ matrix.simd_mode }})
+      working-directory: ${{ github.workspace }}/build-simd-${{ matrix.simd_mode }}
+      run: ctest --build-config Release --output-on-failure
+
 
 

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -176,10 +176,9 @@ jobs:
         simd_mode: [avx2, sse2, no-simd]
         include:
           - simd_mode: avx2
-            # Auto-detection will find AVX2 on GitHub's ubuntu-latest runners.
-            # Pass no extra flags; the build system selects -mavx2 automatically.
+            # Force AVX2 so __AVX2__ branch is compiled deterministically.
             cmake_no_simd: "OFF"
-            cmake_extra_flags: ""
+            cmake_extra_flags: "-DCMAKE_CXX_FLAGS=-mavx2"
           - simd_mode: sse2
             # Force SSE2-only path by disabling auto-detected AVX2.
             # -mno-avx2 prevents __AVX2__ from being defined so the SSE2 branch compiles.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ option(BUILD_PYTHON "Build Python Binding" OFF)
 option(CSV_BUILD_SINGLE_INCLUDE_TEST "Build single-header smoke test (requires Python)" OFF)
 option(ENABLE_CODE_COVERAGE "Enable code coverage instrumentation" OFF)
 option(CSV_ENABLE_THREADS "Enable multi-threaded CSV parsing" ON)
+option(CSV_NO_SIMD "Disable SIMD fast paths at compile time" OFF)
 
 if(EMSCRIPTEN AND CSV_ENABLE_THREADS)
   message(STATUS "Emscripten target detected: forcing CSV_ENABLE_THREADS=OFF")
@@ -45,7 +46,9 @@ if(MSVC)
 	# See: https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
   # /Wall emits warnings about the C++ standard library
 	# /permissive- enables standards conformance (disables MSVC extensions)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc /GS- /Zc:__cplusplus /W4 /permissive-")
+	# /arch:AVX2 enables AVX2 intrinsics and defines __AVX2__; unlike GCC/Clang,
+	# MSVC does not define __AVX2__ from hardware detection alone.
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc /GS- /Zc:__cplusplus /W4 /permissive- /arch:AVX2")
 else()
 	# Ignore Visual Studio pragma regions
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,9 @@ endif()
 
 if(MSVC)
 	# Make Visual Studio report accurate C++ version
-	# See: https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
   # /Wall emits warnings about the C++ standard library
 	# /permissive- enables standards conformance (disables MSVC extensions)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc /GS- /Zc:__cplusplus /W4 /permissive-")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc /GS- /W4 /permissive-")
 else()
 	# Ignore Visual Studio pragma regions
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
@@ -182,18 +181,4 @@ if (CSV_DEVELOPER)
     ## Tests
     enable_testing()
     add_subdirectory("tests")
-
-    # Code coverage
-    #find_program( GCOV_PATH gcov )
-    #if(GCOV_PATH)
-    #    set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules")
-    #    include(CodeCoverage)
-    #    append_coverage_compiler_flags()
-    #    set(ENV{CSV_TEST_ROOT} ${CSV_TEST_DIR})
-    #    setup_target_for_coverage_gcovr_html(
-    #      NAME csv_coverage
-    #      EXECUTABLE csv_test
-    #      EXCLUDE "tests/*"
-    #    )
-    #endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,9 +46,7 @@ if(MSVC)
 	# See: https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
   # /Wall emits warnings about the C++ standard library
 	# /permissive- enables standards conformance (disables MSVC extensions)
-	# /arch:AVX2 enables AVX2 intrinsics and defines __AVX2__; unlike GCC/Clang,
-	# MSVC does not define __AVX2__ from hardware detection alone.
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc /GS- /Zc:__cplusplus /W4 /permissive- /arch:AVX2")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc /GS- /Zc:__cplusplus /W4 /permissive-")
 else()
 	# Ignore Visual Studio pragma regions
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
@@ -60,6 +58,31 @@ else()
 		set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} --coverage -Og -fprofile-update=atomic")
 	endif()
 endif(MSVC)
+
+# Auto-detect the best SIMD tier available on the build host, unless the user
+# has explicitly disabled SIMD or overridden the arch flags themselves.
+# cmake_host_system_information(HAS_AVX2) queries the CPU running cmake,
+# which is the right heuristic for native builds.
+# CSV_NO_SIMD=ON is the escape hatch for cross-compilation, constrained
+# environments, or explicit scalar-only builds (e.g. csv_bench_no_simd).
+if(NOT CSV_NO_SIMD AND NOT CMAKE_CROSSCOMPILING)
+	cmake_host_system_information(RESULT _csv_host_has_avx2 QUERY HAS_AVX2)
+	if(_csv_host_has_avx2)
+		if(MSVC)
+			# MSVC does not define __AVX2__ from hardware detection alone
+			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX2")
+		else()
+			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2")
+		endif()
+		message(STATUS "CSV SIMD: AVX2 detected and enabled")
+	else()
+		message(STATUS "CSV SIMD: AVX2 not available, SSE2 will be used on x86-64")
+	endif()
+elseif(CSV_NO_SIMD)
+	message(STATUS "CSV SIMD: disabled (CSV_NO_SIMD=ON)")
+elseif(CMAKE_CROSSCOMPILING)
+	message(STATUS "CSV SIMD: host detection skipped (cross-compiling); set compiler flags manually if needed")
+endif()
 
 set(CSV_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})
 set(CSV_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(CSV_BUILD_SINGLE_INCLUDE_TEST "Build single-header smoke test (requires P
 option(ENABLE_CODE_COVERAGE "Enable code coverage instrumentation" OFF)
 option(CSV_ENABLE_THREADS "Enable multi-threaded CSV parsing" ON)
 option(CSV_NO_SIMD "Disable SIMD fast paths at compile time" OFF)
+option(CSV_FORCE_AVX2 "Force AVX2 compiler flags for this build" OFF)
 
 if(EMSCRIPTEN AND CSV_ENABLE_THREADS)
   message(STATUS "Emscripten target detected: forcing CSV_ENABLE_THREADS=OFF")
@@ -59,29 +60,23 @@ else()
 	endif()
 endif(MSVC)
 
-# Auto-detect the best SIMD tier available on the build host, unless the user
-# has explicitly disabled SIMD or overridden the arch flags themselves.
-# cmake_host_system_information(HAS_AVX2) queries the CPU running cmake,
-# which is the right heuristic for native builds.
-# CSV_NO_SIMD=ON is the escape hatch for cross-compilation, constrained
-# environments, or explicit scalar-only builds (e.g. csv_bench_no_simd).
-if(NOT CSV_NO_SIMD AND NOT CMAKE_CROSSCOMPILING)
-	cmake_host_system_information(RESULT _csv_host_has_avx2 QUERY HAS_AVX2)
-	if(_csv_host_has_avx2)
-		if(MSVC)
-			# MSVC does not define __AVX2__ from hardware detection alone
-			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX2")
-		else()
-			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2")
-		endif()
-		message(STATUS "CSV SIMD: AVX2 detected and enabled")
-	else()
-		message(STATUS "CSV SIMD: AVX2 not available, SSE2 will be used on x86-64")
-	endif()
-elseif(CSV_NO_SIMD)
-	message(STATUS "CSV SIMD: disabled (CSV_NO_SIMD=ON)")
+# SIMD policy:
+# - CSV_NO_SIMD=ON: hard-disable SIMD in code
+# - CSV_FORCE_AVX2=ON: force AVX2 codegen flags
+# - default: use compiler's default ISA baseline (SSE2 on x86-64, scalar elsewhere)
+if(CSV_NO_SIMD)
+  message(STATUS "CSV SIMD: disabled (CSV_NO_SIMD=ON)")
+elseif(CSV_FORCE_AVX2)
+  if(MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX2")
+  else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2")
+  endif()
+  message(STATUS "CSV SIMD: AVX2 forced (CSV_FORCE_AVX2=ON)")
 elseif(CMAKE_CROSSCOMPILING)
-	message(STATUS "CSV SIMD: host detection skipped (cross-compiling); set compiler flags manually if needed")
+  message(STATUS "CSV SIMD: cross-compiling; using compiler defaults (set arch flags manually to force AVX2)")
+else()
+  message(STATUS "CSV SIMD: using compiler default ISA (SSE2 on x86-64; pass CSV_FORCE_AVX2=ON to force AVX2)")
 endif()
 
 set(CSV_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,21 +62,18 @@ endif(MSVC)
 
 # SIMD policy:
 # - CSV_NO_SIMD=ON: hard-disable SIMD in code
-# - CSV_FORCE_AVX2=ON: force AVX2 codegen flags
-# - default: use compiler's default ISA baseline (SSE2 on x86-64, scalar elsewhere)
+# - default: enable AVX2 codegen (MSVC always; others use CI matrix or manual flags)
 if(CSV_NO_SIMD)
   message(STATUS "CSV SIMD: disabled (CSV_NO_SIMD=ON)")
-elseif(CSV_FORCE_AVX2)
+else()
+  # On MSVC, __AVX2__ is only defined if /arch:AVX2 is explicit, so always add it
+  # On GCC/Clang, CI matrix or user supplies flags; assume baseline ISA here
   if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX2")
+    message(STATUS "CSV SIMD: AVX2 enabled (MSVC /arch:AVX2 added)")
   else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2")
+    message(STATUS "CSV SIMD: default config (CI/user supplies ISA flags if needed)")
   endif()
-  message(STATUS "CSV SIMD: AVX2 forced (CSV_FORCE_AVX2=ON)")
-elseif(CMAKE_CROSSCOMPILING)
-  message(STATUS "CSV SIMD: cross-compiling; using compiler defaults (set arch flags manually to force AVX2)")
-else()
-  message(STATUS "CSV SIMD: using compiler default ISA (SSE2 on x86-64; pass CSV_FORCE_AVX2=ON to force AVX2)")
 endif()
 
 set(CSV_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})

--- a/README.md
+++ b/README.md
@@ -38,17 +38,17 @@
 There's plenty of other CSV parsers in the wild, but I had a hard time finding what I wanted. Inspired by Python's `csv` module, I wanted a library with **simple, intuitive syntax**. Furthermore, I wanted support for special use cases such as calculating statistics on very large files. Thus, this library was created with these following goals in mind.
 
 ### Performance and Memory Requirements
-A high performance CSV parser allows you to take advantage of the deluge of large datasets available. By using overlapped threads, memory mapped IO, and 
-minimal memory allocation, this parser can quickly tackle large CSV files--even if they are larger than RAM.
+A high-performance CSV parser lets you take advantage of large datasets efficiently. This library combines SIMD-accelerated parsing, memory-mapped I/O, careful memory layout, minimal allocation, and background parsing to process large CSV files quickly, even when they exceed available RAM.
 
 In fact, [according to Visual Studio's profiler](https://github.com/vincentlaucsb/csv-parser/wiki/Microsoft-Visual-Studio-CPU-Profiling-Results) this
 CSV parser **spends almost 90% of its CPU cycles actually reading your data** as opposed to getting hung up in hard disk I/O or pushing around memory.
 
 #### Show me the numbers
-On my computer (12th Gen Intel(R) Core(TM) i5-12400 @ 2.50 GHz/Western Digital Blue 5400RPM HDD), this parser can read
- * the [69.9 MB 2015_StateDepartment.csv](https://github.com/vincentlaucsb/csv-data/tree/master/real_data) in 0.19 seconds (360 MBps)
+On my computer (12th Gen Intel(R) Core(TM) i5-12400 @ 2.50 GHz; Samsung 990 EVO), this parser can read
  * a [1.4 GB Craigslist Used Vehicles Dataset](https://www.kaggle.com/austinreese/craigslist-carstrucks-data/version/7) in 1.18 seconds (1.2 GBps)
- * a [2.9GB Car Accidents Dataset](https://www.kaggle.com/sobhanmoosavi/us-accidents) in 8.49 seconds (352 MBps)
+ * a [2.9GB Car Accidents Dataset](https://www.kaggle.com/sobhanmoosavi/us-accidents) in 6.9 seconds (420 MBps)
+
+All benchmarks shown are warm cache runs to focus on parser/CPU performance rather than disk I/O variability.
 
 #### Chunk Size Tuning
 
@@ -125,6 +125,8 @@ While C++17 is recommended, C++11 is the minimum version required. This library 
 [Martin Moene's string view library](https://github.com/martinmoene/string-view-lite) if `std::string_view` is not available.
 
 This library requires C++ exceptions to be enabled (for example, do not compile with `-fno-exceptions`).
+
+SIMD acceleration is enabled by default when the build/compiler flags support it. If needed, you can force scalar-only parsing with `CSV_NO_SIMD=ON` in CMake or by defining `CSV_NO_SIMD 1` before including the library headers.
 
 ### Threading Modes
 By default, `csv-parser` uses a background thread to parse file-based input. If CMake cannot find a thread library, threading is disabled automatically.

--- a/include/csv.hpp
+++ b/include/csv.hpp
@@ -1,5 +1,5 @@
 /*
-CSV for C++, version 3.1.0
+CSV for C++, version 3.2.0
 https://github.com/vincentlaucsb/csv-parser
 
 MIT License

--- a/include/internal/CMakeLists.txt
+++ b/include/internal/CMakeLists.txt
@@ -30,6 +30,10 @@ target_sources(csv
 
 set_target_properties(csv PROPERTIES LINKER_LANGUAGE CXX)
 
+if(CSV_NO_SIMD)
+	target_compile_definitions(csv PUBLIC CSV_NO_SIMD=1)
+endif()
+
 if(CSV_ENABLE_THREADS)
 	target_compile_definitions(csv PUBLIC CSV_ENABLE_THREADS=1)
 	target_link_libraries(csv PRIVATE Threads::Threads)
@@ -38,3 +42,18 @@ else()
 endif()
 
 target_include_directories(csv INTERFACE ../)
+
+# Scalar-only variant of the library: same sources, CSV_NO_SIMD defined.
+# Used by csv_bench_no_simd to provide a fair apples-to-apples benchmark.
+add_library(csv_no_simd STATIC "")
+get_target_property(_csv_sources csv SOURCES)
+target_sources(csv_no_simd PRIVATE ${_csv_sources})
+set_target_properties(csv_no_simd PROPERTIES LINKER_LANGUAGE CXX)
+target_compile_definitions(csv_no_simd PUBLIC CSV_NO_SIMD=1)
+if(CSV_ENABLE_THREADS)
+	target_compile_definitions(csv_no_simd PUBLIC CSV_ENABLE_THREADS=1)
+	target_link_libraries(csv_no_simd PRIVATE Threads::Threads)
+else()
+	target_compile_definitions(csv_no_simd PUBLIC CSV_ENABLE_THREADS=0)
+endif()
+target_include_directories(csv_no_simd INTERFACE ../)

--- a/include/internal/basic_csv_parser.cpp
+++ b/include/internal/basic_csv_parser.cpp
@@ -67,6 +67,10 @@ namespace csv {
                 _parse_flags = internals::make_parse_flags(format.get_delim(), format.quote_char);
             }
 
+            // When no_quote, quote bytes are NOT_SPECIAL — use delimiter as safe dummy
+            // so SIMD does not stop early on quote bytes and cause an infinite loop.
+            const char eff_quote = format.no_quote ? format.get_delim() : format.quote_char;
+            _simd_sentinels = SentinelVecs(format.get_delim(), eff_quote);
             _ws_flags = internals::make_ws_flags(
                 format.trim_chars.data(), format.trim_chars.size()
             );
@@ -103,8 +107,16 @@ namespace csv {
                 field_start = (int)(data_pos - current_row_start());
 
             // Optimization: Since NOT_SPECIAL characters tend to occur in contiguous
-            // sequences, use the loop below to avoid having to go through the outer
-            // switch statement as much as possible
+            // sequences, use SIMD to skip long runs of them quickly.
+            // find_next_non_special processes complete SIMD lanes and returns pos
+            // unchanged for any tail shorter than one lane width.
+#if !defined(CSV_NO_SIMD)
+            data_pos = find_next_non_special(in, data_pos, this->_simd_sentinels);
+#endif
+
+            // Scalar tail: handles remaining bytes after SIMD falls through, and
+            // handles any byte that SIMD stopped at conservatively (e.g. a delimiter
+            // inside a quoted field, which compound_parse_flag treats as NOT_SPECIAL).
             while (data_pos < in.size() && compound_parse_flag(in[data_pos]) == ParseFlags::NOT_SPECIAL)
                 data_pos++;
 

--- a/include/internal/basic_csv_parser.hpp
+++ b/include/internal/basic_csv_parser.hpp
@@ -14,6 +14,7 @@
 #if !defined(__EMSCRIPTEN__)
 #include "../external/mio.hpp"
 #endif
+#include "basic_csv_parser_simd.hpp"
 #include "col_names.hpp"
 #include "common.hpp"
 #include "csv_format.hpp"
@@ -57,6 +58,30 @@ namespace csv {
             return ret;
         }
 
+        inline char infer_delimiter(const ParseFlagMap& parse_flags) noexcept {
+            for (int i = 0; i < 256; ++i) {
+                char ch = static_cast<char>(i);
+                if (parse_flags[ch + CHAR_OFFSET] == ParseFlags::DELIMITER) {
+                    return ch;
+                }
+            }
+
+            return ',';
+        }
+
+        // fallback is returned when no QUOTE flag exists in parse_flags (e.g. no_quote mode).
+        // Pass the delimiter so SIMD stops there instead of on a byte that is NOT_SPECIAL.
+        inline char infer_quote_char(const ParseFlagMap& parse_flags, char fallback = '"') noexcept {
+            for (int i = 0; i < 256; ++i) {
+                char ch = static_cast<char>(i);
+                if (parse_flags[ch + CHAR_OFFSET] == ParseFlags::QUOTE) {
+                    return ch;
+                }
+            }
+
+            return fallback;
+        }
+
         /** Create a vector v where each index i corresponds to the
          *  ASCII number for a character c and, v[i + 128] is true if
          *  c is a whitespace character
@@ -92,8 +117,13 @@ namespace csv {
         public:
             IBasicCSVParser() = default;
             IBasicCSVParser(const CSVFormat&, const ColNamesPtr&);
-            IBasicCSVParser(const ParseFlagMap& parse_flags, const WhitespaceMap& ws_flags
-            ) : _parse_flags(parse_flags), _ws_flags(ws_flags) {}
+            IBasicCSVParser(
+                const ParseFlagMap& parse_flags,
+                const WhitespaceMap& ws_flags
+            ) : _parse_flags(parse_flags), _ws_flags(ws_flags) {
+                const char d = internals::infer_delimiter(parse_flags);
+                _simd_sentinels = SentinelVecs(d, internals::infer_quote_char(parse_flags, d));
+            }
 
             virtual ~IBasicCSVParser() {}
 
@@ -128,6 +158,9 @@ namespace csv {
             CSVFieldList* fields = nullptr;
             int field_start = UNINITIALIZED_FIELD;
             size_t field_length = 0;
+
+            /** Precomputed SIMD broadcast vectors for find_next_non_special */
+            SentinelVecs _simd_sentinels;
 
             /** An array where the (i + 128)th slot gives the ParseFlags for ASCII character i */
             ParseFlagMap _parse_flags;

--- a/include/internal/basic_csv_parser_simd.hpp
+++ b/include/internal/basic_csv_parser_simd.hpp
@@ -1,0 +1,109 @@
+#pragma once
+/** @file
+ *  @brief SIMD-accelerated skip for runs of non-special CSV bytes.
+ *
+ *  Conservative design: any byte that could be the delimiter, quote character,
+ *  \n, or \r causes an early return.
+ *
+ *  Uses 4x cmpeq rather than a lookup-table shuffle because CSV has only four
+ *  sentinel characters. vpshufb (shuffle) truncates index bytes to their low
+ *  nibble, causing aliasing across 16-byte boundaries and silently skipping
+ *  real delimiters. The cmpeq approach is alias-free and equally fast for
+ *  small sentinel sets.
+ *
+ *  UTF-8 safe: all CSV structural bytes are single-byte ASCII; multi-byte
+ *  sequences (values > 0x7F) are never misidentified as special.
+ */
+#include "common.hpp"
+
+#if (defined(__AVX2__) || defined(__SSE2__)) && !defined(CSV_NO_SIMD)
+#include <immintrin.h>
+#endif
+
+namespace csv {
+    namespace internals {
+        // Precomputed SIMD broadcast vectors for the four CSV sentinel bytes.
+        // Constructed once per parser instance and passed by const-ref into
+        // find_next_non_special, amortizing broadcast cost across every field
+        // scan — meaningful for CSVs with many short fields.
+        //
+        // When no_quote mode is active, set quote_char = delimiter so that
+        // quote bytes are not mistakenly treated as sentinels (they are
+        // NOT_SPECIAL in that mode and must not cause SIMD to stop early).
+        struct SentinelVecs {
+            SentinelVecs() noexcept : SentinelVecs(',', '"') {}
+
+            SentinelVecs(char delimiter, char quote_char) noexcept {
+#if defined(__AVX2__) && !defined(CSV_NO_SIMD)
+                v_delim = _mm256_set1_epi8(delimiter);
+                v_quote = _mm256_set1_epi8(quote_char);
+                v_lf    = _mm256_set1_epi8('\n');
+                v_cr    = _mm256_set1_epi8('\r');
+#elif defined(__SSE2__) && !defined(CSV_NO_SIMD)
+                v_delim = _mm_set1_epi8(delimiter);
+                v_quote = _mm_set1_epi8(quote_char);
+                v_lf    = _mm_set1_epi8('\n');
+                v_cr    = _mm_set1_epi8('\r');
+#else
+                (void)delimiter; (void)quote_char;
+#endif
+            }
+
+#if defined(__AVX2__) && !defined(CSV_NO_SIMD)
+            __m256i v_delim, v_quote, v_lf, v_cr;
+#elif defined(__SSE2__) && !defined(CSV_NO_SIMD)
+            __m128i v_delim, v_quote, v_lf, v_cr;
+#endif
+        };
+
+        // Free function — easy to unit test independently of IBasicCSVParser.
+        //
+        // SIMD-only fast-forward: skips pos forward past any bytes that are
+        // definitely not one of the four CSV sentinel characters. Stops as
+        // soon as a sentinel byte is found OR fewer bytes remain than one
+        // SIMD lane. The caller is responsible for the scalar tail loop using
+        // compound_parse_flag, which correctly handles quote_escape state.
+        //
+        // State-agnostic by design: stops conservatively at any sentinel byte
+        // regardless of quote_escape. Inside a quoted field, delimiter and
+        // newline bytes are NOT_SPECIAL under compound_parse_flag, so the
+        // outer DFA loop re-enters parse_field immediately at zero cost.
+        inline size_t find_next_non_special(
+            csv::string_view data,
+            size_t pos,
+            const SentinelVecs& sentinels
+        ) noexcept
+        {
+#if defined(__AVX2__) && !defined(CSV_NO_SIMD)
+            while (pos + 32 <= data.size()) {
+                __m256i bytes   = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(data.data() + pos));
+                __m256i special = _mm256_cmpeq_epi8(bytes, sentinels.v_delim);
+                special         = _mm256_or_si256(special, _mm256_cmpeq_epi8(bytes, sentinels.v_quote));
+                special         = _mm256_or_si256(special, _mm256_cmpeq_epi8(bytes, sentinels.v_lf));
+                special         = _mm256_or_si256(special, _mm256_cmpeq_epi8(bytes, sentinels.v_cr));
+                int mask        = _mm256_movemask_epi8(special);
+
+                if (mask != 0)
+                    return pos + _tzcnt_u32(mask);
+                pos += 32;
+            }
+#elif defined(__SSE2__) && !defined(CSV_NO_SIMD)
+            while (pos + 16 <= data.size()) {
+                __m128i bytes   = _mm_loadu_si128(reinterpret_cast<const __m128i*>(data.data() + pos));
+                __m128i special = _mm_cmpeq_epi8(bytes, sentinels.v_delim);
+                special         = _mm_or_si128(special, _mm_cmpeq_epi8(bytes, sentinels.v_quote));
+                special         = _mm_or_si128(special, _mm_cmpeq_epi8(bytes, sentinels.v_lf));
+                special         = _mm_or_si128(special, _mm_cmpeq_epi8(bytes, sentinels.v_cr));
+                int mask        = _mm_movemask_epi8(special);
+
+                if (mask != 0)
+                    return pos + _tzcnt_u32(mask);
+                pos += 16;
+            }
+#else
+            (void)data; (void)sentinels;
+#endif
+            return pos;
+        }
+    }
+}

--- a/include/internal/basic_csv_parser_simd.hpp
+++ b/include/internal/basic_csv_parser_simd.hpp
@@ -18,6 +18,15 @@
 
 #if (defined(__AVX2__) || defined(__SSE2__)) && !defined(CSV_NO_SIMD)
 #include <immintrin.h>
+// _tzcnt_u32 in GCC/Clang headers is __attribute__(__target__("bmi")), which
+// requires -mbmi at the call site. __builtin_ctz has no such restriction and
+// emits BSF/TZCNT as the optimizer sees fit. MSVC's _tzcnt_u32 has no
+// equivalent restriction, so keep it there.
+#  ifdef _MSC_VER
+#    define CSV_TZCNT32(x) _tzcnt_u32(x)
+#  else
+#    define CSV_TZCNT32(x) static_cast<unsigned>(__builtin_ctz(x))
+#  endif
 #endif
 
 namespace csv {
@@ -84,7 +93,7 @@ namespace csv {
                 int mask        = _mm256_movemask_epi8(special);
 
                 if (mask != 0)
-                    return pos + _tzcnt_u32(mask);
+                    return pos + CSV_TZCNT32(static_cast<unsigned>(mask));
                 pos += 32;
             }
 #elif defined(__SSE2__) && !defined(CSV_NO_SIMD)
@@ -97,7 +106,7 @@ namespace csv {
                 int mask        = _mm_movemask_epi8(special);
 
                 if (mask != 0)
-                    return pos + _tzcnt_u32(mask);
+                    return pos + CSV_TZCNT32(static_cast<unsigned>(mask));
                 pos += 16;
             }
 #else

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -13,6 +13,10 @@ if(CSV_DEVELOPER)
 	add_executable(csv_bench ${CMAKE_CURRENT_LIST_DIR}/csv_bench.cpp)
 	target_link_libraries(csv_bench csv)
 
+	# Scalar-only build for side-by-side SIMD vs no-SIMD comparison
+	add_executable(csv_bench_no_simd ${CMAKE_CURRENT_LIST_DIR}/csv_bench.cpp)
+	target_link_libraries(csv_bench_no_simd csv_no_simd)
+
 	add_custom_target(generate_csv_bench
 		COMMAND csv_bench 2015_StateDepartment.csv
 		WORKING_DIRECTORY ${CSV_TEST_DIR}/data/real_data

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,10 @@ target_sources(csv_test
         test_write_csv.cpp
     )
 
+if(NOT CSV_NO_SIMD)
+    target_sources(csv_test PRIVATE test_basic_csv_parser_simd.cpp)
+endif()
+
 if(CSV_ENABLE_THREADS)
     target_sources(csv_test PRIVATE test_threadsafe_deque_race.cpp)
 endif()

--- a/tests/test_basic_csv_parser_simd.cpp
+++ b/tests/test_basic_csv_parser_simd.cpp
@@ -74,7 +74,7 @@ TEST_CASE("SIMD skip handles custom delimiter and quote", "[simd][parser]") {
     }
 }
 
-TEST_CASE("SentinelVecs with dummy quote does not stop on quote bytes", "[simd][parser]") {
+TEST_CASE("SIMD no_quote sentinel config ignores quote bytes", "[simd][parser]") {
     // Simulates no_quote mode: SentinelVecs constructed with delimiter as dummy
     // for the quote slot. SIMD must not stop at '"' bytes because v_quote
     // broadcasts ',' (same as v_delim), so only real ',' bytes halt the scan.

--- a/tests/test_basic_csv_parser_simd.cpp
+++ b/tests/test_basic_csv_parser_simd.cpp
@@ -1,0 +1,108 @@
+#include <catch2/catch_all.hpp>
+#include "internal/basic_csv_parser.hpp"
+
+#include <string>
+
+using namespace csv;
+using namespace csv::internals;
+
+// find_next_non_special is SIMD-only: it fast-forwards through complete lanes
+// that contain no sentinel bytes, then returns. The caller's scalar loop handles
+// the sub-lane tail. When data is shorter than one lane, the function is a noop.
+
+TEST_CASE("SIMD skip returns end for lane-aligned non-special run", "[simd][parser]") {
+    // 512 bytes is a multiple of both AVX2 (32) and SSE2 (16) lane widths,
+    // so the function processes every byte and reaches the end.
+    const SentinelVecs sentinels(',', '"');
+
+    std::string data(512, 'a');
+    const auto pos = find_next_non_special(data, 0, sentinels);
+
+    REQUIRE(pos == data.size());
+}
+
+TEST_CASE("SIMD skip returns pos unchanged when data shorter than one lane", "[simd][parser]") {
+    // 8 bytes < minimum SIMD lane width (16 for SSE2). No complete lane to
+    // process — function returns the start pos immediately. The caller's
+    // scalar loop is responsible for these bytes.
+    const SentinelVecs sentinels(',', '"');
+
+    std::string data(8, 'x');
+    const auto pos = find_next_non_special(data, 3, sentinels);
+
+    REQUIRE(pos == 3);
+}
+
+TEST_CASE("SIMD skip finds delimiter at key boundary offsets", "[simd][parser]") {
+    const SentinelVecs sentinels(',', '"');
+
+    const size_t target = GENERATE(0u, 1u, 15u, 16u, 17u, 31u, 32u, 33u, 63u, 64u, 95u);
+
+    std::string data(128, 'x');
+    data[target] = ',';
+
+    const auto pos = find_next_non_special(data, 0, sentinels);
+    REQUIRE(pos == target);
+}
+
+TEST_CASE("SIMD skip respects start offset", "[simd][parser]") {
+    const SentinelVecs sentinels(',', '"');
+
+    std::string data(160, 'z');
+    data[12] = ',';
+    data[97] = ',';
+
+    const auto pos = find_next_non_special(data, 20, sentinels);
+    REQUIRE(pos == 97);
+}
+
+TEST_CASE("SIMD skip handles custom delimiter and quote", "[simd][parser]") {
+    const SentinelVecs sentinels('|', '~');
+
+    std::string data(128, 'm');
+    data[41] = '|';
+    data[88] = '~';
+
+    SECTION("Custom delimiter found first") {
+        const auto pos = find_next_non_special(data, 0, sentinels);
+        REQUIRE(pos == 41);
+    }
+
+    SECTION("Custom quote found from later start") {
+        const auto pos = find_next_non_special(data, 42, sentinels);
+        REQUIRE(pos == 88);
+    }
+}
+
+TEST_CASE("SentinelVecs with dummy quote does not stop on quote bytes", "[simd][parser]") {
+    // Simulates no_quote mode: SentinelVecs constructed with delimiter as dummy
+    // for the quote slot. SIMD must not stop at '"' bytes because v_quote
+    // broadcasts ',' (same as v_delim), so only real ',' bytes halt the scan.
+    // 128 bytes with sentinel at 99 is well within SIMD range.
+    const SentinelVecs sentinels(',', ',');
+
+    std::string data(128, 'a');
+    data[10] = '"';   // quote chars scattered through field -- must NOT stop SIMD
+    data[33] = '"';
+    data[65] = '"';
+    data[99] = ',';   // real delimiter -- must stop here
+
+    const auto pos = find_next_non_special(data, 0, sentinels);
+    REQUIRE(pos == 99);
+}
+
+TEST_CASE("SIMD skip treats UTF-8 bytes as non-special content", "[simd][parser]") {
+    const SentinelVecs sentinels(',', '"');
+
+    std::string data;
+    data.reserve(192);
+
+    for (size_t i = 0; i < 64; ++i) {
+        data.push_back(static_cast<char>(0xC3));
+        data.push_back(static_cast<char>(0xA9));
+        data.push_back('a');
+    }
+
+    const auto pos = find_next_non_special(data, 0, sentinels);
+    REQUIRE(pos == data.size());
+}


### PR DESCRIPTION
# Summary
Added AVX2 (primary) + SSE2 (fallback) SIMD acceleration to the hot scanning path in find_next_non_special().
After profiling, it became clear that a significant portion of CPU time was spent in a tight loop responsible for skipping over runs of insignificant (non-delimiter, non-quote, non-newline) characters.

This optimization uses SIMD instructions to accelerate that common case while preserving the original battle-tested DFA state machine for correctness. The SIMD path only handles the “boring” skipping work — all complex logic (quoting, escaping, custom delimiters, line ending handling) remains unchanged in the scalar fallback.

## Key Design Decisions
 * Conservative approach: SIMD is disabled inside quoted/escaped fields to guarantee correctness.
 * No changes to public API or observed behavior.
 * Falls back gracefully to the original scalar loop when SIMD cannot be used.

## Measurements
The CSV Parser's benchmarking program was easily able to maintain 530MB/s on an SSD while reading a 11GB NextStrain SARS-CoV-2 sequence metadata file.
<img width="790" height="319" alt="image" src="https://github.com/user-attachments/assets/08321c2f-5193-4a97-b91b-964f43901516" />

When profiled, 81% of CPU cycles are in the main parse loop
<img width="999" height="908" alt="image" src="https://github.com/user-attachments/assets/67276d5c-bce8-408e-be3a-b2629ff0ba3c" />

The hot loop remains hot, but the SIMD optimization takes off some pressure
<img width="1004" height="620" alt="image" src="https://github.com/user-attachments/assets/88523795-1947-4566-be90-cd82550c029b" />
