### PR TITLE
Fix ColNames::index_of for non-NUL-terminated string_view

### DIFF
--- a/include/internal/col_names.cpp
+++ b/include/internal/col_names.cpp
@@ -36,7 +36,7 @@ namespace csv {
                 return (pos != this->col_pos.end()) ? (int)pos->second : CSV_NOT_FOUND;
             }
 
-            auto pos = this->col_pos.find(col_name.data());
+            auto pos = this->col_pos.find(std::string(col_name));
             return (pos != this->col_pos.end()) ? (int)pos->second : CSV_NOT_FOUND;
         }
 

--- a/tests/test_col_names.cpp
+++ b/tests/test_col_names.cpp
@@ -195,3 +195,24 @@ TEST_CASE("ColNames - duplicate column names: last index wins", "[col_names][edg
     REQUIRE(cn.index_of("dup") == 2);
     REQUIRE(cn.index_of("other") == 1);
 }
+
+TEST_CASE("ColNames - index_of accepts non-NUL-terminated string_view", "[col_names][edge_cases]") {
+    // Regression: index_of used to look up via col_name.data(), which is
+    // implicitly converted to std::string by scanning to a NUL byte. When the
+    // string_view is a slice of a larger buffer with no NUL at view.end(),
+    // the lookup reads past the view and resolves to the wrong (or nonexistent)
+    // column.
+    ColNames cn({"Name", "Age"});
+
+    const std::string buf = "NameAge";
+    // sv covers only "Name" (4 bytes), but buf.data() continues into "Age\0".
+    csv::string_view sv(buf.data(), 4);
+    REQUIRE(cn.index_of(sv) == 0);
+
+    // Same construction under the case-insensitive policy is already correct;
+    // pin it so a future refactor cannot regress that branch either.
+    ColNames cn_ci;
+    cn_ci.set_policy(ColumnNamePolicy::CASE_INSENSITIVE);
+    cn_ci.set_col_names({"Name", "Age"});
+    REQUIRE(cn_ci.index_of(sv) == 0);
+}


### PR DESCRIPTION
## Summary

`ColNames::index_of(csv::string_view)` (`include/internal/col_names.cpp:39`) calls `col_pos.find(col_name.data())` in the exact-policy branch.

`col_pos` is a `std::unordered_map<std::string, size_t>`, and `col_name.data()` decays to `const char *`. The implicit conversion to `std::string` then reads until the next NUL byte, which may be past the end of the `string_view` whenever the underlying buffer is not NUL-terminated at `data() + size()`.

The case-insensitive branch a few lines above already does the right thing by constructing a bounded string:

```cpp
std::string lower(col_name);
```

So this is a missed conversion in the exact-policy branch only.

## Reproduction

Current behavior:

```cpp
ColNames cn({"Name", "Age"});

const std::string buf = "NameAge";
csv::string_view sv(buf.data(), 4);  // "Name", but data() continues into "Age\0"

cn.index_of(sv);  // returns CSV_NOT_FOUND (-1) instead of 0
```

The same trip is reachable through `CSVRow::operator[](csv::string_view)` (`csv_row.cpp:51`) for any user that constructs a `string_view` as a slice of a larger buffer.

## Fix

Construct the `std::string` lookup key from the `string_view` explicitly, matching the case-insensitive branch.

```diff
- auto item = col_pos.find(col_name.data());
+ auto item = col_pos.find(std::string(col_name));
```

This ensures the lookup key is built from exactly `col_name.size()` bytes instead of reading past the end of the view.

## Test

Adds `ColNames - index_of accepts non-NUL-terminated string_view` in `tests/test_col_names.cpp`.

With the buggy code, the test fails:

```text
cn.index_of(sv) == 0
-1 == 0
```

With the fix, all 54 assertions across the file pass.

Verified locally on macOS with Apple clang and C++20.
